### PR TITLE
Implement Steward Protocol for HERALD

### DIFF
--- a/herald/cartridge_main.py
+++ b/herald/cartridge_main.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from herald.tools.research_tool import ResearchTool
 from herald.tools.content_tool import ContentTool
 from herald.tools.broadcast_tool import BroadcastTool
+from herald.tools.identity_tool import IdentityTool
 
 logger = logging.getLogger("HERALD_CARTRIDGE")
 
@@ -58,6 +59,7 @@ class HeraldCartridge:
         self.research = ResearchTool()
         self.content = ContentTool()
         self.broadcast = BroadcastTool()
+        self.identity = IdentityTool()
 
         # Execution metadata
         self.execution_id = None
@@ -131,6 +133,20 @@ class HeraldCartridge:
         logger.info(f"✅ Content generated: {len(tweet)} chars")
         logger.info(f"   Preview: {tweet[:80]}...")
 
+        # Step 2.5: Sign Content (Steward Protocol Integration)
+        logger.info("\n🦅 PHASE 2.5: IDENTITY")
+        logger.info("=" * 70)
+
+        signature = None
+        if self.identity.assert_identity():
+            signature = self.identity.sign_artifact(tweet)
+            if signature:
+                logger.info(f"✅ Content signed: {signature[:40]}...")
+            else:
+                logger.warning("⚠️  Signing attempted but failed (no credentials)")
+        else:
+            logger.debug("ℹ️  Identity not available, skipping signature")
+
         # Step 3: Approval Gate
         logger.info("\n🦅 PHASE 3: GOVERNANCE")
         logger.info("=" * 70)
@@ -146,6 +162,7 @@ class HeraldCartridge:
             "context": research_context or "No trending topic",
             "platform": "twitter",
             "dry_run": dry_run,
+            "signature": signature,
         }
 
         self.last_result = result

--- a/herald/tools/__init__.py
+++ b/herald/tools/__init__.py
@@ -5,10 +5,12 @@ Each tool encapsulates a capability:
 - ResearchTool: Market intelligence via Tavily
 - ContentTool: LLM-based content generation with governance
 - BroadcastTool: Social media publishing (Twitter, Reddit)
+- IdentityTool: Cryptographic signing via Steward Protocol
 """
 
 from .research_tool import ResearchTool
 from .content_tool import ContentTool
 from .broadcast_tool import BroadcastTool
+from .identity_tool import IdentityTool
 
-__all__ = ["ResearchTool", "ContentTool", "BroadcastTool"]
+__all__ = ["ResearchTool", "ContentTool", "BroadcastTool", "IdentityTool"]

--- a/herald/tools/identity_tool.py
+++ b/herald/tools/identity_tool.py
@@ -1,0 +1,169 @@
+"""
+HERALD Identity Tool - Cryptographic signing via Steward Protocol.
+
+Provides agent identity verification and content signing capabilities.
+Integrates HERALD with the Steward Protocol for cryptographic integrity.
+"""
+
+import logging
+from typing import Optional, Dict, Any
+from pathlib import Path
+
+try:
+    from steward.client import StewardClient
+    from steward import crypto
+except ImportError:
+    StewardClient = None
+    crypto = None
+
+logger = logging.getLogger("HERALD_IDENTITY")
+
+
+class IdentityTool:
+    """
+    Cryptographic identity and signing tool for HERALD.
+
+    Capabilities:
+    - sign_artifact: Sign content with HERALD's private key
+    - assert_identity: Verify that HERALD has cryptographic credentials
+    - get_public_key: Retrieve HERALD's public key for verification
+    """
+
+    def __init__(self, identity_file: str = "herald/STEWARD.md"):
+        """
+        Initialize identity tool with HERALD's identity file.
+
+        Args:
+            identity_file: Path to HERALD's STEWARD.md identity file
+        """
+        self.identity_file = Path(identity_file)
+        self.client = None
+        self.public_key = None
+
+        if not StewardClient or not crypto:
+            logger.warning("⚠️  Steward Protocol not available (not installed)")
+            return
+
+        try:
+            self.client = StewardClient(identity_file=str(self.identity_file))
+            logger.info(f"✅ Identity: Steward client initialized with {self.identity_file}")
+        except Exception as e:
+            logger.warning(f"⚠️  Identity: Failed to initialize Steward client: {e}")
+
+    def assert_identity(self) -> bool:
+        """
+        Verify that HERALD has cryptographic credentials available.
+
+        This checks that:
+        1. The private key exists and is readable
+        2. The identity file is properly configured
+        3. The keypair is valid
+
+        Returns:
+            bool: True if identity is valid and keys are available
+        """
+        if not self.client:
+            logger.warning("⚠️  Identity: Steward client not available")
+            return False
+
+        try:
+            result = self.client.assert_identity()
+            if result:
+                logger.info("✅ Identity: Cryptographic credentials verified")
+            else:
+                logger.warning("⚠️  Identity: Credentials not verified")
+            return result
+        except Exception as e:
+            logger.warning(f"⚠️  Identity: Assertion failed: {e}")
+            return False
+
+    def sign_artifact(self, content: str) -> Optional[str]:
+        """
+        Cryptographically sign a text artifact (tweet, post, etc.).
+
+        Uses HERALD's private key to create a digital signature.
+        The signature can be used to verify that HERALD created this content.
+
+        Args:
+            content: The text to sign
+
+        Returns:
+            str: Base64-encoded signature, or None if signing failed
+        """
+        if not content:
+            logger.error("❌ Identity: Cannot sign empty content")
+            return None
+
+        if not self.client:
+            logger.warning("⚠️  Identity: Steward client not available, skipping signature")
+            return None
+
+        try:
+            signature = self.client.sign_artifact(content.strip())
+            logger.info(f"✅ Identity: Content signed ({len(signature)} char signature)")
+            return signature
+        except Exception as e:
+            logger.error(f"❌ Identity: Signing failed: {e}")
+            return None
+
+    def get_public_key(self) -> Optional[str]:
+        """
+        Get HERALD's public key for verification.
+
+        The public key is embedded in the identity file and can be used
+        to verify any signature created by sign_artifact().
+
+        Returns:
+            str: Base64-encoded public key, or None if not available
+        """
+        if self.public_key:
+            return self.public_key
+
+        if not crypto:
+            logger.warning("⚠️  Identity: Crypto module not available")
+            return None
+
+        try:
+            self.public_key = crypto.get_public_key_string()
+            logger.debug(f"✅ Identity: Public key retrieved ({len(self.public_key)} chars)")
+            return self.public_key
+        except Exception as e:
+            logger.warning(f"⚠️  Identity: Could not retrieve public key: {e}")
+            return None
+
+    def create_signed_record(self, content: str) -> Optional[Dict[str, Any]]:
+        """
+        Create a complete signed record of the content.
+
+        This is a convenience method that signs content and returns
+        both the content and signature in a structured format.
+
+        Args:
+            content: The text to sign and record
+
+        Returns:
+            dict: {
+                "content": str,
+                "signature": str,
+                "public_key": str (optional)
+            }
+            or None if signing failed
+        """
+        signature = self.sign_artifact(content)
+        if not signature:
+            return None
+
+        record = {
+            "content": content,
+            "signature": signature,
+        }
+
+        public_key = self.get_public_key()
+        if public_key:
+            record["public_key"] = public_key
+
+        return record
+
+
+# Export for Herald use
+__all__ = ["IdentityTool"]

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+HERALD Identity Setup - Generate and register cryptographic keys.
+
+This script sets up HERALD's Steward Protocol identity by:
+1. Generating a new ECDSA keypair (NIST P-256, SHA256)
+2. Displaying the public key for embedding in STEWARD.md
+3. Providing instructions for securing the private key
+
+The private key will be stored in `.steward/keys/private.pem` (user-only access).
+You must then add the key to GitHub Secrets as `HERALD_PRIVATE_KEY` for CI/CD pipelines.
+
+Usage:
+    python scripts/setup_identity.py
+"""
+
+import sys
+import os
+from pathlib import Path
+
+try:
+    from steward import crypto
+except ImportError:
+    print("❌ ERROR: 'steward' module not found")
+    print("   Please ensure you're running this from the project root")
+    print("   and that the steward package is installed.")
+    sys.exit(1)
+
+
+def print_banner(title: str):
+    """Print a formatted banner."""
+    print("\n" + "=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+
+
+def main():
+    """Main setup flow."""
+    print_banner("🦅 HERALD Identity Setup - Steward Protocol v3.1")
+
+    # Step 1: Generate keypair
+    print("\n[STEP 1] Generating cryptographic keypair...")
+    print("   Algorithm: ECDSA (Elliptic Curve Digital Signature)")
+    print("   Curve: NIST P-256")
+    print("   Hash: SHA256")
+
+    try:
+        newly_created = crypto.ensure_keys_exist()
+        if newly_created:
+            print("   ✅ New keypair generated")
+        else:
+            print("   ℹ️  Keypair already exists")
+    except Exception as e:
+        print(f"   ❌ FAILED: {e}")
+        sys.exit(1)
+
+    # Step 2: Show public key
+    print("\n[STEP 2] Retrieving public key...")
+    try:
+        public_key = crypto.get_public_key_string()
+        print(f"   ✅ Public key retrieved ({len(public_key)} characters)")
+    except Exception as e:
+        print(f"   ❌ FAILED: {e}")
+        sys.exit(1)
+
+    # Step 3: Show private key location
+    print("\n[STEP 3] Private key location...")
+    private_key_path = Path.home() / ".steward" / "keys" / "private.pem"
+    print(f"   📁 Private key stored at: {private_key_path}")
+    print(f"   🔐 Permissions: Owner-only (0o600)")
+    print(f"   ⚠️  NEVER commit this file to git")
+
+    # Step 4: Instructions for GitHub Secrets
+    print_banner("Next Steps: Register Identity in GitHub")
+    print("\n1. Add public key to herald/STEWARD.md:")
+    print(f"\n   ```yaml\n   - **key:** `{public_key}`\n   ```\n")
+
+    print("2. Register private key in GitHub Secrets:")
+    print("   a) Go to: https://github.com/kimeisele/steward-protocol/settings/secrets/actions")
+    print("   b) Click 'New repository secret'")
+    print("   c) Name: HERALD_PRIVATE_KEY")
+    print("   d) Value: (paste the contents of private.pem file below)")
+
+    # Step 5: Show private key (for manual entry)
+    print("\n" + "=" * 70)
+    print("  ⚠️  PRIVATE KEY - KEEP THIS SECURE")
+    print("=" * 70)
+
+    try:
+        with open(private_key_path, "r") as f:
+            private_key_content = f.read()
+            print(private_key_content)
+    except FileNotFoundError:
+        print("❌ ERROR: Private key file not found")
+        print(f"   Expected at: {private_key_path}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ ERROR reading private key: {e}")
+        sys.exit(1)
+
+    # Final instructions
+    print_banner("✅ Identity Setup Complete")
+    print("\n✅ Status: HERALD is now registered as a Steward Protocol Agent")
+    print("📋 Action required: Add the public key and private key to GitHub")
+    print("🚀 Once done, HERALD can sign all generated content cryptographically")
+    print("")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement cryptographic signing for HERALD tweets via Steward Protocol:

1. herald/tools/identity_tool.py: New IdentityTool for artifact signing
   - Wraps StewardClient for agent identity verification
   - Methods: assert_identity(), sign_artifact(), get_public_key()
   - Graceful fallback if Steward Protocol not available

2. scripts/setup_identity.py: Identity setup automation
   - Generates ECDSA keypair (NIST P-256, SHA256)
   - Displays public key for STEWARD.md registration
   - Shows private key for GitHub Secrets configuration

3. herald/cartridge_main.py: Integrate signing into workflow
   - Phase 2.5: IDENTITY - Sign content after generation
   - Phase 2.5 → Phase 3 (Approval) → Phase 4 (Publish)
   - Result includes signature for audit trail
   - Graceful handling if identity not available

This enables "dogfooding": HERALD now uses its own protocol to prove content origin. Signature verification supports future audit and compliance workflows.