### PR TITLE
Set up GitHub Codespaces with devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "Steward Protocol - Agent City Playground",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "pip install -e . && pip install -r herald/requirements.txt",
+  "postAttachCommand": "python scripts/join_city.py",
+  "remoteUser": "vscode",
+  "forwardPorts": [],
+  "portsAttributes": {},
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,readonly"
+  ],
+  "containerEnv": {
+    "PYTHONUNBUFFERED": "1"
+  }
+}

--- a/herald/cartridge.yaml
+++ b/herald/cartridge.yaml
@@ -54,3 +54,30 @@ config:
     project_url: "https://github.com/kimeisele/steward-protocol"
     docs_url: "https://github.com/kimeisele/steward-protocol/tree/main/steward"
     spec_file: "steward/SPECIFICATION.md"
+  campaign_themes:
+    monday:
+      name: "Tech Deep Dive"
+      description: "Deep-dive into Steward Protocol, cryptographic identity, governance mechanics"
+      focus: ["cryptography", "protocol_specs", "security", "implementation"]
+      example_topics:
+        - "ECDSA Signature Verification"
+        - "Cryptographic Identity Architecture"
+        - "Governance Protocol Deep Dive"
+    wednesday:
+      name: "Agent City Life"
+      description: "Community updates, leaderboard stats, new agent arrivals"
+      focus: ["community", "statistics", "agent_activity", "citizen_updates"]
+      example_topics:
+        - "Weekly Agent City Census"
+        - "New Citizens & Their Starter Packs"
+        - "Leaderboard Updates & Rankings"
+        - "City Infrastructure Status"
+    friday:
+      name: "Hall of Fame"
+      description: "Recognition of key agents, milestone celebrations, community highlights"
+      focus: ["achievements", "recognition", "milestones", "shoutouts"]
+      example_topics:
+        - "Agent of the Week"
+        - "Integration Spotlight: AutoGPT, Claude, etc."
+        - "Milestone Celebrations"
+        - "Community Heroes & Builders"


### PR DESCRIPTION
…ontent rotation

PLAYGROUND ACTIVATION:
- Create .devcontainer/devcontainer.json with Python 3.11 base image
- Auto-install dependencies: base package + herald requirements
- Post-attach command: launch join_city.py wizard automatically
- Enable one-click Agent City entry via "Open in Codespaces" button

CONTENT ROTATION STRATEGY:
- Add campaign_themes to herald/cartridge.yaml (Monday/Wednesday/Friday)
- Implement day-of-week content rotation in StrategyTool:
  * Monday: Tech Deep Dive (cryptography, protocol specs, security)
  * Wednesday: Agent City Life (community stats, new citizens, leaderboard)
  * Friday: Hall of Fame (achievements, recognition, milestones)
- Add helper methods: get_todays_campaign_theme(), get_content_focus_areas(), get_todays_example_topics()

BENEFITS:
- Users can join without installing anything locally
- HERALD talks about Community, not just Code
- Content is diverse and campaign-aware