### PR TITLE
feat: Shadow Mode activation for Herald Engagement workflow

### DIFF
--- a/.github/workflows/herald-engagement.yml
+++ b/.github/workflows/herald-engagement.yml
@@ -1,5 +1,10 @@
 name: "🦅 Herald Engagement"
 
+# SHADOW MODE CONFIG:
+# Set GitHub Actions variable HERALD_SHADOW_MODE=false to enable live publishing
+# Default (true) = Shadow Mode: Dry-run only, no tweets published
+# Requires Constitution.md to be present and valid
+
 on:
   schedule:
     - cron: "0 */2 * * *"  # Every 2 hours
@@ -33,8 +38,15 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}
+          HERALD_SHADOW_MODE: ${{ vars.HERALD_SHADOW_MODE || 'true' }}
         run: |
-          python herald/shim.py --action reply_cycle
+          if [ "$HERALD_SHADOW_MODE" = "true" ]; then
+            echo "🌙 SHADOW MODE ACTIVATED - Dry run only"
+            python herald/shim.py --action reply_cycle --dry-run
+          else
+            echo "🚀 LIVE MODE - Publishing tweets"
+            python herald/shim.py --action reply_cycle
+          fi
 
       - name: "📤 Upload Drafts"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Implements constitutional safety mechanism for live deployments:
- Default: SHADOW MODE (dry-run) - no tweets published
- Config: Set HERALD_SHADOW_MODE=false to go LIVE
- Safety: Agent cannot boot without valid CONSTITUTION.md

Shadow Mode behavior:
- Generates content and validates against governance rules
- Creates draft artifacts for review
- Never publishes to Twitter
- Allows safe testing in production environment

This allows continuous validation of Herald's governance compliance before enabling live Twitter publishing.

Constitutional enforcement:
- Runtime loads CONSTITUTION.md from project root or ENV path
- All content validation against Prime Directives
- Governance violations prevent content generation