### PR TITLE
Add missing API key header validation

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -250,7 +250,10 @@
                 // KARMA (Action/Sending)
                 const response = await fetch('/v1/chat', {
                     method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-api-key': 'steward-secret-key'
+                    },
                     body: JSON.stringify(signedPayload)
                 });
 


### PR DESCRIPTION
The frontend was sending signed payloads to /v1/chat without the required x-api-key header. The gateway expects this header for authorization. This completes the authentication handshake: identity + authorization.