### PR TITLE
Fix API endpoint method not allowed error

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -247,8 +247,11 @@
                 appendLog("🔒 Signing Vector...", "system");
                 const signedPayload = await wallet.signPayload(txt);
 
+                // 🔥 HARDCODED TARGET: Forces conversation to local kernel
+                const TARGET_URL = "http://localhost:8000/v1/chat";
+
                 // KARMA (Action/Sending)
-                const response = await fetch('/v1/chat', {
+                const response = await fetch(TARGET_URL, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -256,6 +259,13 @@
                     },
                     body: JSON.stringify(signedPayload)
                 });
+
+                // Error Handling für "Unexpected token <" (HTML statt JSON)
+                const contentType = response.headers.get("content-type");
+                if (!contentType || !contentType.includes("application/json")) {
+                    const text = await response.text();
+                    throw new Error(`Server returned non-JSON response (HTTP ${response.status}): ${text.substring(0, 100)}...`);
+                }
 
                 const data = await response.json();
 
@@ -268,6 +278,9 @@
 
             } catch (e) {
                 appendLog(`❌ TRANSMISSION ERROR: ${e.message}`, 'error');
+                if (e.message.includes("Failed to fetch")) {
+                    appendLog("💡 HINT: Is the backend running? Open http://localhost:8000", "system");
+                }
             }
         }
 


### PR DESCRIPTION
…rror handling

- Changed fetch URL from relative /v1/chat to absolute http://localhost:8000/v1/chat
- This fixes 405 Method Not Allowed error when frontend is loaded from GitHub Pages
- Added content-type validation to detect and handle non-JSON responses
- Added helpful error hints for connection failures