### PR TITLE
Test Gateway functionality with Docker

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: steward-gateway
+    runtime: docker
+    branch: main
+    dockerfilePath: ./Dockerfile
+    envVars:
+      - key: PORT
+        value: 8080
+      - key: GOVERNANCE_MODE
+        value: SERVERLESS_BYPASS
+      - key: ENV
+        value: production
+      - key: PYTHONPATH
+        value: /app


### PR DESCRIPTION
This pull request adds a new deployment configuration for the `steward-gateway` service in the `render.yaml` file. The configuration sets up the service to run as a Docker-based web service with production environment variables.

Deployment configuration:

* Added a new `web` service entry for `steward-gateway` with Docker runtime and specified the main branch and Dockerfile path.
* Configured environment variables for the service, including `PORT`, `GOVERNANCE_MODE`, `ENV`, and `PYTHONPATH`.… branch