### PR TITLE
fix: Convert relative imports to absolute for Late Binding compatibility

### DIFF
--- a/agent_city/registry/artisan/cartridge_main.py
+++ b/agent_city/registry/artisan/cartridge_main.py
@@ -13,21 +13,18 @@ REFACTORED: Tool Protocol Compliant
 import logging
 from typing import Any, Dict
 
+# Constitutional Oath Mixin (Golden Template Pattern)
+from steward.oath_mixin import OathMixin
+
 # VibeOS Integration
 from vibe_core import Task, VibeAgent
-
-# Constitutional Oath Mixin
-try:
-    from steward.oath_mixin import OathMixin
-except ImportError:
-    OathMixin = None
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("ARTISAN_AGENT")
 
 
-class ArtisanCartridge(VibeAgent):
+class ArtisanCartridge(VibeAgent, OathMixin):
     """
     The Artisan Agent Cartridge.
     Specialized in media processing and technical operations.
@@ -52,12 +49,10 @@ class ArtisanCartridge(VibeAgent):
 
         logger.info("🔨 THE ARTISAN is online (Tool Protocol v2.0).")
 
-        # Initialize Constitutional Oath mixin (if available)
-        if OathMixin:
-            self.oath_mixin_init(self.agent_id)
-            # SWEAR THE OATH IMMEDIATELY in __init__
-            self.oath_sworn = True
-            logger.info("✅ ARTISAN has sworn the Constitutional Oath")
+        # Golden Template Pattern: Initialize Constitutional Oath
+        self.oath_mixin_init(self.agent_id)
+        self.oath_sworn = True
+        logger.info("✅ ARTISAN has sworn the Constitutional Oath")
 
         # ALL TOOLS: Accessed via kernel (self.system.execute_tool)
         # - artisan.media (MediaTool)
@@ -130,6 +125,8 @@ class ArtisanCartridge(VibeAgent):
             agent_id="artisan",
             name="ARTISAN",
             version=self.version if hasattr(self, "version") else "2.0.0",
+            author="Steward Protocol",
+            description="Media and technical operations agent",
             domain="MEDIA",
             capabilities=["media_operations", "content_creation"],
         )

--- a/agent_city/registry/dhruva/cartridge_main.py
+++ b/agent_city/registry/dhruva/cartridge_main.py
@@ -39,19 +39,20 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List
 
+# NOTE: Absolute imports required for Late Binding (ProcessManager loads via importlib)
+from agent_city.registry.dhruva.tools.data_ethics import DataEthicsEnforcer
+from agent_city.registry.dhruva.tools.genesis_keeper import GenesisKeeper
+from agent_city.registry.dhruva.tools.reference_resolver import ReferenceResolver
+from agent_city.registry.dhruva.tools.truth_matrix import TruthMatrix
+
+# Constitutional Oath Mixin (Golden Template Pattern)
+from steward.oath_mixin import OathMixin
 from vibe_core.agent_protocol import AgentManifest, Capability, VibeAgent
-
-from .tools.data_ethics import DataEthicsEnforcer
-from .tools.genesis_keeper import GenesisKeeper
-from .tools.reference_resolver import ReferenceResolver
-
-# Constitutional Oath binding
-from .tools.truth_matrix import TruthMatrix
 
 logger = logging.getLogger("DHRUVA_ANCHOR")
 
 
-class DhruvaAnchorCartridge(VibeAgent):
+class DhruvaAnchorCartridge(VibeAgent, OathMixin):
     """
     DHRUVA ANCHOR - The Immutable Truth Reference & Stability System.
 
@@ -84,11 +85,10 @@ class DhruvaAnchorCartridge(VibeAgent):
             ],
         )
 
-        # Bind to Constitutional Oath (GAD-000 compliance)
-        if OathMixin:
-            self.oath_mixin_init(self.agent_id)
-            self.oath_sworn = True
-            logger.info("✅ DHRUVA ANCHOR has sworn the Constitutional Oath")
+        # Golden Template Pattern: Bind to Constitutional Oath
+        self.oath_mixin_init(self.agent_id)
+        self.oath_sworn = True
+        logger.info("✅ DHRUVA ANCHOR has sworn the Constitutional Oath")
 
         logger.info("🧭 DHRUVA ANCHOR v1.0: Initializing Immutable Reference System")
 

--- a/steward/system_agents/civic/cartridge_main.py
+++ b/steward/system_agents/civic/cartridge_main.py
@@ -30,13 +30,14 @@ import yaml
 # Constitutional Oath Mixin
 from steward.oath_mixin import OathMixin
 
+# NOTE: Absolute imports required for Late Binding (ProcessManager loads via importlib)
+from steward.system_agents.civic.economy_agent import EconomyAgent
+from steward.system_agents.civic.lifecycle_agent import LifecycleAgent
+from steward.system_agents.civic.registry_agent import RegistryAgent
+
 # VibeOS Integration
 from vibe_core import Task, VibeAgent
 from vibe_core.config import CivicConfig
-
-from .economy_agent import EconomyAgent
-from .lifecycle_agent import LifecycleAgent
-from .registry_agent import RegistryAgent
 
 # Import delegated components
 
@@ -118,8 +119,9 @@ class CivicCartridge(VibeAgent, OathMixin):
         self.economy_agent = EconomyAgent()
         self.lifecycle_agent = LifecycleAgent()
 
-        # Load state for parent coordination
-        self.state = self._load_state()
+        # State will be loaded lazily after system interface injection
+        # (self.system is not available in __init__)
+        self.state = {}
 
         logger.info("🏛️  CIVIC: Ready for operation (awaiting kernel injection)")
 
@@ -142,6 +144,9 @@ class CivicCartridge(VibeAgent, OathMixin):
         self.economy_agent.set_system(self.system)
         self.lifecycle_agent.set_system(self.system)
         logger.info("✅ CIVIC sub-agents now have access to system interface")
+
+        # Load state now that self.system is available
+        self.state = self._load_state()
 
     @property
     def registry_path(self):

--- a/steward/system_agents/discoverer/cartridge_main.py
+++ b/steward/system_agents/discoverer/cartridge_main.py
@@ -19,7 +19,8 @@ that enables all other agents to exist.
 import logging
 from typing import Any, Dict
 
-from .agent import Discoverer
+# NOTE: Absolute import required for Late Binding (ProcessManager loads via importlib)
+from steward.system_agents.discoverer.agent import Discoverer
 
 logger = logging.getLogger("DISCOVERER_CARTRIDGE")
 

--- a/steward/system_agents/herald/cartridge_main.py
+++ b/steward/system_agents/herald/cartridge_main.py
@@ -48,8 +48,9 @@ except ImportError:
 # Constitutional Oath Mixin
 from steward.oath_mixin import OathMixin
 
-from .core.memory import EventLog
-from .governance import HeraldConstitution
+# NOTE: Absolute imports required for Late Binding (ProcessManager loads via importlib)
+from steward.system_agents.herald.core.memory import EventLog
+from steward.system_agents.herald.governance import HeraldConstitution
 
 # Constitutional Oath
 # Setup logging

--- a/steward/system_agents/supreme_court/cartridge_main.py
+++ b/steward/system_agents/supreme_court/cartridge_main.py
@@ -32,12 +32,13 @@ from typing import Any, Dict, Optional
 
 # Constitutional Oath Mixin
 from steward.oath_mixin import OathMixin
-from vibe_core.config import CivicConfig
-from vibe_core.protocols import AgentManifest, Capability, VibeAgent
 
 # Import enums for external use (not tool instances)
-from .tools.appeals_tool import AppealStatus
-from .tools.verdict_tool import VerdictType
+# NOTE: Absolute imports required for Late Binding (ProcessManager loads via importlib)
+from steward.system_agents.supreme_court.tools.appeals_tool import AppealStatus
+from steward.system_agents.supreme_court.tools.verdict_tool import VerdictType
+from vibe_core.config import CivicConfig
+from vibe_core.protocols import AgentManifest, Capability, VibeAgent
 
 # Constitutional Oath binding
 


### PR DESCRIPTION
System-Agents and citizen-agents with relative imports fail when loaded via ProcessManager's Late Binding (importlib.util.spec_from_file_location) because the module has no package context.

Import fixes:
- supreme_court: Convert .tools.* → steward.system_agents.supreme_court.tools.*
- discoverer: Convert .agent → steward.system_agents.discoverer.agent
- civic: Convert .economy_agent etc. → steward.system_agents.civic.*
- herald: Convert .core.* → steward.system_agents.herald.core.*
- dhruva: Convert .tools.* → agent_city.registry.dhruva.tools.*

Golden Template Pattern fixes:
- artisan: Add OathMixin inheritance + oath_mixin_init() + oath_sworn
- artisan: Add missing author/description to get_manifest()
- dhruva: Add OathMixin inheritance (was referencing undefined OathMixin)

Initialization order fix:
- civic: Move _load_state() from __init__ to set_kernel() to avoid accessing self.system before kernel injection

All 28 agents now boot successfully with full process isolation.