### PR TITLE
feat: Implement SettingsExecutor for RESTART/REFRESH/verbose commands

### DIFF
--- a/vibe_core/kernel_impl.py
+++ b/vibe_core/kernel_impl.py
@@ -53,6 +53,7 @@ from .resource_manager import ResourceManager  # Phase 3: Resource Isolation
 from .runtime.playbook_router import PlaybookRouter
 from .sarga import Cycle, get_sarga
 from .scheduling import Task
+from .settings_executor import get_executor as get_settings_executor
 
 # Sync modules: Extracted bidirectional markdown interfaces
 from .settings_sync import SettingsSync, SettingsSyncState
@@ -312,6 +313,7 @@ class RealVibeKernel(VibeKernel):
 
         # SettingsSync: Bidirectional SETTINGS.md interface (extracted from kernel)
         self._settings_sync = SettingsSync()
+        self._settings_executor = get_settings_executor()
         logger.info("⚙️  SettingsSync initialized (command queue)")
 
         # EnvoySync: Bidirectional ENVOY.md interface (extracted from kernel)
@@ -880,6 +882,10 @@ class RealVibeKernel(VibeKernel):
             self._settings_last_modified = result.new_mtime
             self._paused_agents = result.paused_agents
             self._settings_execution_history.extend(result.history_entries)
+
+            # Execute commands that require kernel access (RESTART, REFRESH, verbose)
+            # This is delegated to SettingsExecutor to keep kernel clean
+            self._settings_executor.execute(result, self)
 
         # ENVOY.md: Check for new user requests and dispatch tasks (async, non-blocking)
         # Uses PlaybookRouter for intent routing - NO LLM NEEDED

--- a/vibe_core/settings_executor.py
+++ b/vibe_core/settings_executor.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+SettingsExecutor - Executes settings commands from SETTINGS.md
+
+SEPARATED FROM kernel_impl.py to keep kernel clean.
+
+This module handles the ACTUAL execution of settings commands:
+- RESTART agent.<id> → Actually restarts the agent process
+- REFRESH topology → Actually refreshes the topology
+- SET kernel.verbose → Actually changes logging behavior
+
+The kernel just calls: executor.execute(result)
+No complex logic in kernel.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Set
+
+from vibe_core.settings_sync import SettingsExecutionResult
+
+if TYPE_CHECKING:
+    from vibe_core.kernel_impl import RealVibeKernel
+
+logger = logging.getLogger(__name__)
+
+
+class SettingsExecutor:
+    """
+    Executes settings commands that require kernel access.
+
+    Usage in kernel tick():
+        result = settings_sync.sync_to_reality(state, ledger_callback)
+        executor.execute(result, self)  # self = kernel
+    """
+
+    def execute(self, result: SettingsExecutionResult, kernel: "RealVibeKernel") -> None:
+        """
+        Execute all pending settings commands.
+
+        Args:
+            result: The result from SettingsSync.execute_commands()
+            kernel: Reference to the kernel for process/topology access
+        """
+        # Handle RESTART commands
+        if result.restart_agents:
+            self._execute_restarts(result.restart_agents, kernel)
+
+        # Handle REFRESH topology
+        if result.refresh_topology:
+            self._execute_refresh_topology(kernel)
+
+        # Handle verbose mode
+        if result.verbose_mode is not None:
+            self._execute_verbose_mode(result.verbose_mode)
+
+    def _execute_restarts(self, agent_ids: Set[str], kernel: "RealVibeKernel") -> None:
+        """
+        Restart specified agents via ProcessManager.
+
+        Uses the same logic as crash recovery but triggered manually.
+        """
+        for agent_id in agent_ids:
+            try:
+                # Check if agent exists in process manager
+                if agent_id not in kernel.process_manager.processes:
+                    logger.warning(f"⚠️  Cannot restart '{agent_id}': not a process-isolated agent")
+                    continue
+
+                info = kernel.process_manager.processes[agent_id]
+
+                # Terminate existing process gracefully
+                if info.process.is_alive():
+                    logger.info(f"🔄 Stopping agent '{agent_id}' for restart...")
+                    info.parent_pipe.send({"type": "STOP"})
+                    info.process.join(timeout=2)
+
+                    if info.process.is_alive():
+                        logger.warning(f"⚠️  Agent '{agent_id}' didn't stop gracefully, terminating...")
+                        info.process.terminate()
+                        info.process.join(timeout=1)
+
+                # Use ProcessManager's internal restart logic
+                # Set status to CRASHED to trigger _handle_crash logic
+                from vibe_core.process_manager import ProcessStatus
+
+                info.status = ProcessStatus.CRASHED
+                kernel.process_manager._handle_crash(agent_id)
+
+                logger.info(f"✅ Agent '{agent_id}' restarted successfully")
+
+            except Exception as e:
+                logger.error(f"❌ Failed to restart agent '{agent_id}': {e}")
+
+    def _execute_refresh_topology(self, kernel: "RealVibeKernel") -> None:
+        """
+        Force refresh the agent topology.
+        """
+        try:
+            from vibe_core.topology import refresh_topology
+
+            logger.info("🔄 Refreshing topology...")
+            topology = refresh_topology(kernel=kernel)
+
+            agent_count = len(topology.agents) if hasattr(topology, "agents") else 0
+            logger.info(f"✅ Topology refreshed ({agent_count} agents)")
+
+        except Exception as e:
+            logger.error(f"❌ Failed to refresh topology: {e}")
+
+    def _execute_verbose_mode(self, enabled: bool) -> None:
+        """
+        Enable or disable verbose logging mode.
+
+        When enabled: Sets root logger and VIBE_KERNEL to DEBUG
+        When disabled: Restores to INFO level
+        """
+        try:
+            level = logging.DEBUG if enabled else logging.INFO
+
+            # Set root logger
+            logging.getLogger().setLevel(level)
+
+            # Set kernel-specific loggers
+            for logger_name in ["VIBE_KERNEL", "PROCESS_MANAGER", "vibe_core"]:
+                logging.getLogger(logger_name).setLevel(level)
+
+            mode = "ENABLED" if enabled else "DISABLED"
+            logger.info(f"📊 Verbose mode {mode} (log level: {logging.getLevelName(level)})")
+
+        except Exception as e:
+            logger.error(f"❌ Failed to set verbose mode: {e}")
+
+
+# Singleton instance for kernel to use
+_executor: SettingsExecutor | None = None
+
+
+def get_executor() -> SettingsExecutor:
+    """Get the singleton SettingsExecutor instance."""
+    global _executor
+    if _executor is None:
+        _executor = SettingsExecutor()
+    return _executor


### PR DESCRIPTION
NO MORE MOCKS - Commands actually execute now:

- RESTART agent.<id>: Stops agent process, triggers ProcessManager restart
- REFRESH topology: Calls refresh_topology() to rediscover agents
- SET kernel.verbose=true: Changes logging level to DEBUG/INFO

Architecture:
- settings_executor.py: New module handles execution (keeps kernel clean)
- Kernel just calls executor.execute(result, self) after sync
- All complex logic is in executor, not kernel

Tested:
- Verbose mode: Toggles logging level correctly
- Refresh topology: Discovers 27 agents
- Restart: Gracefully handles non-process agents