### PR TITLE
feat: GitHub Pages static docs viewer (hybrid setup)

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -2,205 +2,314 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>VibeChat // GAD-3000 // PHOENIX</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>STEWARD PROTOCOL - Documentation</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <style>
-        body { background: #050505; color: #00ff41; font-family: 'Courier New', monospace; padding: 2rem; max-width: 900px; margin: 0 auto; }
-        h1 { border-bottom: 2px solid #00ff41; padding-bottom: 15px; letter-spacing: 2px; }
-        #log { background: #000; border: 1px solid #333; height: 400px; overflow-y: scroll; padding: 15px; margin-bottom: 20px; white-space: pre-wrap; font-size: 0.9rem; }
-        #input-area { display: flex; border: 1px solid #00ff41; }
-        input { flex-grow: 1; background: #000; border: none; color: #fff; padding: 15px; outline: none; font-family: inherit; font-size: 1rem; }
-        button { background: #00ff41; color: #000; border: none; padding: 0 30px; cursor: pointer; font-weight: 900; font-size: 1rem; }
-        button:disabled { background: #333; color: #555; cursor: not-allowed; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
 
-        .system { color: #666; font-style: italic; }
-        .user { color: #0ff; font-weight: bold; margin-top: 10px; display: block; }
-        .agent { color: #f0f; margin-bottom: 10px; display: block; border-left: 2px solid #f0f; padding-left: 10px; }
-        .success { color: #00ff41; font-weight: bold; }
-        .error { color: #ff3333; font-weight: bold; background: rgba(50,0,0,0.5); padding: 2px; }
+        :root {
+            --bg: #0a0e27;
+            --sidebar-bg: #0d1230;
+            --text: #00ff88;
+            --text-dim: #00aa55;
+            --accent: #00ffff;
+            --border: #00ff88;
+            --glow: 0 0 10px rgba(0, 255, 136, 0.3);
+        }
+
+        body {
+            font-family: 'Courier New', monospace;
+            background: var(--bg);
+            color: #e0e0e0;
+            line-height: 1.6;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        .container { display: flex; height: 100vh; }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--sidebar-bg);
+            border-right: 2px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--glow);
+        }
+
+        .sidebar-header {
+            padding: 1.5rem;
+            border-bottom: 1px solid var(--border);
+            text-align: center;
+        }
+
+        .sidebar-header h1 {
+            font-size: 1.3rem;
+            color: var(--text);
+            text-shadow: var(--glow);
+            margin-bottom: 0.5rem;
+        }
+
+        .sidebar-header .subtitle {
+            font-size: 0.75rem;
+            color: var(--text-dim);
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.5rem;
+            background: rgba(0, 255, 136, 0.1);
+            border: 1px solid var(--border);
+            border-radius: 3px;
+            font-size: 0.7rem;
+            color: var(--text);
+            margin-top: 0.5rem;
+        }
+
+        .doc-list {
+            flex: 1;
+            overflow-y: auto;
+            padding: 0.5rem;
+        }
+
+        .doc-section {
+            margin: 0.5rem 0;
+            padding: 0.5rem;
+        }
+
+        .doc-section-title {
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            margin-bottom: 0.5rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .doc-item {
+            padding: 0.6rem 0.8rem;
+            margin: 0.2rem 0;
+            border: 1px solid transparent;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s;
+            color: var(--text);
+        }
+
+        .doc-item:hover {
+            background: rgba(0, 255, 136, 0.1);
+            border-color: var(--border);
+        }
+
+        .doc-item.active {
+            background: rgba(0, 255, 136, 0.2);
+            border-color: var(--text);
+            box-shadow: var(--glow);
+        }
+
+        .sidebar-footer {
+            padding: 1rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 0.75rem;
+        }
+
+        .sidebar-footer a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        .sidebar-footer a:hover { text-decoration: underline; }
+
+        /* Main Content */
+        .main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .main-header {
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--sidebar-bg);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .main-header h2 {
+            color: var(--text);
+            font-size: 1.1rem;
+        }
+
+        .content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 2rem;
+        }
+
+        /* Markdown Styles */
+        .content h1, .content h2, .content h3, .content h4 {
+            color: var(--text);
+            margin: 1.5rem 0 1rem 0;
+            border-bottom: 1px solid rgba(0, 255, 136, 0.3);
+            padding-bottom: 0.5rem;
+        }
+        .content h1 { font-size: 1.8rem; }
+        .content h2 { font-size: 1.4rem; }
+        .content h3 { font-size: 1.2rem; }
+        .content p { margin: 1rem 0; }
+        .content a { color: var(--accent); text-decoration: none; }
+        .content a:hover { text-decoration: underline; }
+        .content code {
+            background: rgba(0, 255, 136, 0.1);
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            color: var(--accent);
+        }
+        .content pre {
+            background: #0d1230;
+            padding: 1rem;
+            border-radius: 4px;
+            overflow-x: auto;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+        .content pre code { background: none; padding: 0; }
+        .content blockquote {
+            border-left: 3px solid var(--text);
+            padding: 0.5rem 1rem;
+            margin: 1rem 0;
+            color: var(--text-dim);
+            background: rgba(0, 255, 136, 0.05);
+        }
+        .content ul, .content ol { margin: 1rem 0; padding-left: 2rem; }
+        .content li { margin: 0.5rem 0; }
+        .content table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+        .content th, .content td {
+            border: 1px solid var(--border);
+            padding: 0.5rem;
+            text-align: left;
+        }
+        .content th { background: rgba(0, 255, 136, 0.1); color: var(--text); }
+        .content hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+        .loading { text-align: center; padding: 3rem; color: var(--text-dim); }
+        .error { text-align: center; padding: 3rem; color: #ff3366; }
     </style>
 </head>
 <body>
-    <h1>👁️ VIBE_CHAT // PHOENIX // GAD-3000</h1>
-    <div id="status">SYSTEM OFFLINE</div>
-    <div id="log"></div>
-    <div id="input-area">
-        <input type="text" id="cmd" placeholder="Initializing Encryption..." disabled>
-        <button id="btn" onclick="sendCommand()" disabled>LOCKED</button>
+    <div class="container">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <h1>STEWARD PROTOCOL</h1>
+                <div class="subtitle">Auto-Generated Documentation</div>
+                <div class="badge">STATIC VIEWER</div>
+            </div>
+            <div class="doc-list">
+                <div class="doc-section">
+                    <div class="doc-section-title">SCRIBE Generated</div>
+                    <div class="doc-item" onclick="loadDoc('README')">README</div>
+                    <div class="doc-item" onclick="loadDoc('INDEX')">INDEX</div>
+                    <div class="doc-item" onclick="loadDoc('AGENTS')">AGENTS</div>
+                    <div class="doc-item" onclick="loadDoc('CITYMAP')">CITYMAP</div>
+                    <div class="doc-item" onclick="loadDoc('HELP')">HELP</div>
+                    <div class="doc-item" onclick="loadDoc('DASHBOARD')">DASHBOARD</div>
+                    <div class="doc-item" onclick="loadDoc('RAG')">RAG</div>
+                </div>
+                <div class="doc-section">
+                    <div class="doc-section-title">Kernel Generated</div>
+                    <div class="doc-item" onclick="loadDoc('OPERATIONS')">OPERATIONS</div>
+                    <div class="doc-item" onclick="loadDoc('SETTINGS')">SETTINGS</div>
+                    <div class="doc-item" onclick="loadDoc('ENVOY')">ENVOY</div>
+                </div>
+            </div>
+            <div class="sidebar-footer">
+                <div>Full Interactive Version:</div>
+                <a href="https://steward-gateway.onrender.com" target="_blank">steward-gateway.onrender.com</a>
+                <div style="margin-top: 0.5rem;">
+                    <a href="https://github.com/kimeisele/steward-protocol" target="_blank">GitHub Repo</a>
+                </div>
+            </div>
+        </aside>
+        <main class="main">
+            <div class="main-header">
+                <h2 id="docTitle">Select a document</h2>
+            </div>
+            <div class="content" id="docContent">
+                <p style="color: var(--text-dim); text-align: center; padding: 3rem;">
+                    Select a document from the sidebar to view its contents.
+                    <br><br>
+                    <span style="color: var(--text);">This is the static documentation viewer.</span>
+                    <br>
+                    For the full interactive experience with Kernel, WebSocket pulse, and command interface:
+                    <br><br>
+                    <a href="https://steward-gateway.onrender.com" style="color: var(--accent);">
+                        Visit steward-gateway.onrender.com
+                    </a>
+                </p>
+            </div>
+        </main>
     </div>
 
     <script>
-        // --- 1. CONFIGURATION (FRESH DATABASE NAME) ---
-        // Durch die Namensänderung erzwingen wir eine frische DB. Kein Konflikt mehr.
-        const DB_NAME = "VibeChat_Phoenix_Final_v1";
-        const STORE_NAME = "keys";
+        const REPO = 'kimeisele/steward-protocol';
+        const BRANCH = 'main';
+        let currentDoc = null;
 
-        // --- 2. IDENTITY WALLET (CORE) ---
-        class IdentityWallet {
-            constructor() { this.keyPair = null; this.db = null; }
+        async function loadDoc(docName) {
+            const content = document.getElementById('docContent');
+            const title = document.getElementById('docTitle');
 
-            async init() {
-                // Environment Check
-                if (!window.crypto || !window.crypto.subtle) {
-                    throw new Error("INSECURE CONTEXT. Please use http://localhost:8000");
+            // Update active state
+            document.querySelectorAll('.doc-item').forEach(item => {
+                item.classList.remove('active');
+                if (item.textContent === docName) {
+                    item.classList.add('active');
                 }
+            });
 
-                await this._openDB();
-                const existing = await this._getKey();
-
-                if (existing) {
-                    this.keyPair = existing;
-                    console.log("[WALLET] Identity restored.");
-                } else {
-                    console.log("[WALLET] Generating new identity...");
-                    this.keyPair = await this._genKeys();
-                    await this._saveKey(this.keyPair);
-                }
-                return await this._expKey(this.keyPair.publicKey);
-            }
-
-            async sign(msg) {
-                if (!this.keyPair) throw new Error("Wallet not ready");
-                const enc = new TextEncoder().encode(msg);
-                const sig = await window.crypto.subtle.sign(
-                    {name:"ECDSA", hash:"SHA-256"},
-                    this.keyPair.privateKey,
-                    enc
-                );
-
-                return {
-                    message: msg,
-                    signature: this._hex(sig),
-                    public_key: await this._expKey(this.keyPair.publicKey),
-                    agent_id: "HIL_OPERATOR",
-                    timestamp: Date.now()
-                };
-            }
-
-            // Crypto Primitives
-            async _genKeys() {
-                return window.crypto.subtle.generateKey(
-                    {name:"ECDSA", namedCurve:"P-256"},
-                    false, ["sign","verify"]
-                );
-            }
-            async _expKey(k) {
-                const buf = await window.crypto.subtle.exportKey("spki", k);
-                return this._hex(buf);
-            }
-            _hex(buf) {
-                return [...new Uint8Array(buf)].map(x=>x.toString(16).padStart(2,'0')).join('');
-            }
-
-            // IndexedDB (ROBUST)
-            _openDB() {
-                return new Promise((resolve, reject) => {
-                    const req = indexedDB.open(DB_NAME, 1);
-
-                    req.onupgradeneeded = (e) => {
-                        console.log("[DB] Creating new object store...");
-                        const db = e.target.result;
-                        if (!db.objectStoreNames.contains(STORE_NAME)) {
-                            db.createObjectStore(STORE_NAME);
-                        }
-                    };
-
-                    req.onsuccess = () => { this.db = req.result; resolve(); };
-                    req.onerror = (e) => reject(`DB Error: ${e.target.error}`);
-                });
-            }
-
-            _getKey() {
-                return new Promise((resolve, reject) => {
-                    const tx = this.db.transaction(STORE_NAME, "readonly");
-                    const req = tx.objectStore(STORE_NAME).get("hil_identity");
-                    req.onsuccess = () => resolve(req.result);
-                    req.onerror = () => reject("Failed to read key");
-                });
-            }
-
-            _saveKey(val) {
-                return new Promise((resolve, reject) => {
-                    const tx = this.db.transaction(STORE_NAME, "readwrite");
-                    const req = tx.objectStore(STORE_NAME).put(val, "hil_identity");
-                    tx.oncomplete = resolve;
-                    tx.onerror = () => reject("Failed to save key");
-                });
-            }
-        }
-
-        // --- 3. UI LOGIC ---
-        const log = document.getElementById('log');
-        const input = document.getElementById('cmd');
-        const btn = document.getElementById('btn');
-        const status = document.getElementById('status');
-        let wallet = null;
-
-        function append(txt, type) {
-            const t = new Date().toLocaleTimeString('de-DE');
-            log.innerHTML += `<div class="${type}">[${t}] ${txt}</div>`;
-            log.scrollTop = log.scrollHeight;
-        }
-
-        // --- 4. BOOT SEQUENCE ---
-        (async () => {
-            append("SYSTEM INIT: Mounting Phoenix Protocol...", "system");
-            try {
-                wallet = new IdentityWallet();
-                const pk = await wallet.init();
-
-                input.disabled = false;
-                btn.disabled = false;
-                input.placeholder = "Enter command (e.g. 'status', 'briefing')...";
-                btn.innerText = "TRANSMIT";
-                input.focus();
-
-                status.innerHTML = `ONLINE | <span class="success">ENCRYPTED</span>`;
-                append(`✅ IDENTITY FUSED.\n🔑 ID: ${pk.substring(0,24)}...`, "success");
-            } catch(e) {
-                status.innerText = "CRITICAL FAILURE";
-                status.style.color = "red";
-                append(`❌ BOOT ERROR: ${e.message}`, "error");
-                console.error(e);
-            }
-        })();
-
-        // --- 5. TRANSMISSION ---
-        async function sendCommand() {
-            const txt = input.value.trim();
-            if(!txt) return;
-
-            append(`> ${txt}`, "user");
-            input.value = "";
+            content.innerHTML = '<div class="loading">Loading...</div>';
+            title.textContent = docName + '.md';
+            currentDoc = docName;
 
             try {
-                append("🔒 Signing payload...", "system");
-                const payload = await wallet.sign(txt);
+                // Fetch from GitHub raw content
+                const url = `https://raw.githubusercontent.com/${REPO}/${BRANCH}/${docName}.md`;
+                const response = await fetch(url);
 
-                const TARGET = "http://localhost:8000/v1/chat";
-
-                const res = await fetch(TARGET, {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "x-api-key": "steward-secret-key"
-                    },
-                    body: JSON.stringify(payload)
-                });
-
-                const data = await res.json();
-
-                if (data.status === "success" || data.status === "SUBMITTED") {
-                    const out = data.summary || JSON.stringify(data, null, 2);
-                    append(out, "agent");
-                } else {
-                    append(`❌ REJECTED: ${JSON.stringify(data)}`, "error");
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
                 }
-            } catch(e) {
-                append(`❌ NETWORK ERROR: ${e.message}`, "error");
+
+                const markdown = await response.text();
+                content.innerHTML = marked.parse(markdown);
+
+                // Make internal doc links work
+                content.querySelectorAll('a').forEach(link => {
+                    const href = link.getAttribute('href');
+                    if (href && href.endsWith('.md') && !href.startsWith('http')) {
+                        link.onclick = (e) => {
+                            e.preventDefault();
+                            loadDoc(href.replace('.md', ''));
+                        };
+                    }
+                });
+            } catch (error) {
+                content.innerHTML = `<div class="error">
+                    Failed to load ${docName}.md<br>
+                    <small>${error.message}</small><br><br>
+                    <a href="https://github.com/${REPO}/blob/${BRANCH}/${docName}.md" target="_blank">
+                        View on GitHub
+                    </a>
+                </div>`;
             }
         }
 
-        input.addEventListener("keypress", e=>{if(e.key==="Enter") sendCommand()});
+        // Auto-load INDEX on page load
+        loadDoc('INDEX');
     </script>
 </body>
 </html>


### PR DESCRIPTION
Replace old chat interface with static docs viewer:
- Fetches markdown from raw.githubusercontent.com
- No backend required (pure client-side)
- Links to Render.com for full interactive version
- Same VIMANA-style dark theme

Architecture:
- GitHub Pages (kimeisele.github.io) = Static docs only
- Render.com (steward-gateway) = Full stack SSOT