### PR TITLE
fix: Add psutil to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN pip install --no-cache-dir \
     python-dotenv \
     cryptography \
     jinja2 \
-    toml
+    toml \
+    psutil
 
 # Copy project files FIRST (as root)
 COPY . .


### PR DESCRIPTION
This pull request introduces a minor update to the `Dockerfile` by adding a new Python dependency. The change ensures that `psutil` will be installed in the Docker environment alongside existing packages.

* Added `psutil` to the list of installed Python packages in the `Dockerfile` to support system and process monitoring features.