### PR TITLE
fix(docker): Fix Render.com deployment dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,33 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
-# Core API dependencies + Jinja2 for docs
+# Core dependencies from pyproject.toml (runtime essentials only)
 RUN pip install --no-cache-dir \
-    fastapi \
-    uvicorn \
-    pydantic \
+    # API Framework
+    fastapi>=0.104.0 \
+    uvicorn>=0.24.0 \
+    pydantic>=2.0.0 \
+    pydantic-settings>=2.0.0 \
     mangum \
+    # HTTP & Async
     httpx \
-    pyyaml \
-    requests \
-    python-dotenv \
-    cryptography \
+    requests>=2.31.0 \
+    aiofiles>=23.2.1 \
+    # Data & Config
+    pyyaml>=6.0.1 \
+    tomlkit>=0.12.0 \
+    python-dotenv>=1.0.0 \
+    jsonschema>=4.17.0 \
+    # Security & Crypto
+    cryptography>=41.0.0 \
+    ecdsa>=0.18.0 \
+    cffi>=1.15.0 \
+    # Rendering & Output
     jinja2 \
-    toml \
-    psutil
+    rich>=13.0.0 \
+    # System Utilities
+    psutil>=7.1.3 \
+    gitpython>=3.1.0
 
 # Copy project files FIRST (as root)
 COPY . .


### PR DESCRIPTION
- Fixes ModuleNotFoundError: No module named 'tomlkit' on Render.com deployment.

Root Cause:
- Dockerfile used 'toml' instead of 'tomlkit' (different packages!)
- Missing runtime dependencies from pyproject.toml

Changes:
- toml → tomlkit (DependencyManager requires tomlkit for format preservation)
- Added pydantic-settings (used by config system)
- Added ecdsa, cffi (crypto dependencies)
- Added aiofiles, jsonschema (async ops)
- Added rich, gitpython (system utilities)
- Pinned versions to match pyproject.toml

All dependencies now match pyproject.toml core requirements for runtime.

Tested: Dockerfile builds successfully locally
Impact: Fixes Render.com deployment crash on startup