### PR TITLE
feat: Add QualityConfig to PhoenixConfig - immortal CI/lint settings

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,7 @@
 # 📋 Mission Control
 
-> **Auto-Generated Task Board** | Last Updated: 2025-12-04 15:04:07  
-> **Status:** 🟢 Operational | **Active Tasks:** 0 | **Completed:** 77
+> **Auto-Generated Task Board** | Last Updated: 2025-12-04 16:53:58
+> **Status:** 🟢 Operational | **Active Tasks:** 0 | **Completed:** 101
 
 ---
 
@@ -30,19 +30,19 @@ No active missions yet.
 ## ✅ Recently Completed
 
 - [x] Routine security patrol @watchman
-  > *Completed: 2025-12-04 15:04*
+  > *Completed: 2025-12-04 16:53*
 
 - [x] Update constitutional amendment @civic
-  > *Completed: 2025-12-04 15:04*
+  > *Completed: 2025-12-04 16:53*
 
 - [x] CRITICAL: System down emergency @auto-routed
-  > *Completed: 2025-12-04 15:04*
+  > *Completed: 2025-12-04 16:53*
 
 - [x] Content generation - HERALD @herald
-  > *Completed: 2025-12-04 15:04*
+  > *Completed: 2025-12-04 16:53*
 
 - [x] Security patrol - WATCHMAN @watchman
-  > *Completed: 2025-12-04 15:04*
+  > *Completed: 2025-12-04 16:53*
 
 ---
 
@@ -50,16 +50,16 @@ No active missions yet.
 
 | Metric | Value |
 |--------|-------|
-| Total Tasks | 78 |
+| Total Tasks | 102 |
 | Pending | 1 |
 | Running | 0 |
-| Completed | 77 |
+| Completed | 101 |
 | Blocked | 0 |
 
 ---
 
 **Heartbeat:** Operational  
-**Last Pulse:** 2025-12-04 15:04:07 UTC  
+**Last Pulse:** 2025-12-04 16:53:58 UTC  
 **Next Check:** ~15 minutes
 
 ---

--- a/config/quality.yaml
+++ b/config/quality.yaml
@@ -1,0 +1,105 @@
+# Quality Configuration - The immortal CI/lint settings
+#
+# This file survives container wipes. It IS the source of truth for:
+# - Lint rules (what errors to catch)
+# - Format rules (how code should look)
+# - Test configuration (how to run tests)
+# - CI workflows (what checks to run)
+#
+# Agents and kernel can read this to understand quality requirements.
+# Pre-commit hooks can be GENERATED from this config.
+
+# =============================================================================
+# LINTING (ruff)
+# =============================================================================
+lint:
+  tool: ruff
+  # Critical rules - CI FAILS on these
+  critical_rules:
+    - E9    # Runtime errors (syntax errors, etc.)
+    - F63   # Invalid print syntax
+    - F7    # Syntax errors in assertions
+    - F82   # Undefined names
+  # Informational rules - shown but don't fail CI
+  info_rules:
+    - E     # pycodestyle errors
+    - F     # pyflakes
+    - I     # isort
+    - W     # pycodestyle warnings
+  # Paths to check
+  paths:
+    - vibe_core
+    - steward
+    - scripts
+  # Paths to exclude
+  exclude:
+    - .git
+    - .venv
+    - __pycache__
+    - data
+    - archive
+    - node_modules
+  line_length: 120
+
+# =============================================================================
+# FORMATTING (ruff format)
+# =============================================================================
+format:
+  tool: ruff
+  auto_fix: true
+  paths:
+    - vibe_core
+    - steward
+    - scripts
+  line_length: 120
+  quote_style: double
+
+# =============================================================================
+# TESTING (pytest)
+# =============================================================================
+test:
+  tool: pytest
+  paths:
+    - tests
+  default_markers: []
+  timeout: 300  # seconds per test
+  workers: 0    # 0 = auto-detect
+  coverage_threshold: 0  # 0 = disabled
+
+# =============================================================================
+# CI WORKFLOWS
+# =============================================================================
+ci:
+  workflows:
+    - name: Lint & Format Check
+      file: steward-ci.yml
+      triggers:
+        - push
+        - pull_request
+      required: true
+
+    - name: Integration Tests
+      file: integration-tests.yml
+      triggers:
+        - push
+        - pull_request
+      required: true
+
+    - name: Scheduled Agents
+      file: scheduled-agents.yml
+      triggers:
+        - schedule
+      required: false
+
+  protected_branches:
+    - main
+    - master
+
+  require_status_checks: true
+
+# =============================================================================
+# ENFORCEMENT
+# =============================================================================
+enforce_on_commit: true
+enforce_on_push: true
+block_on_failure: true

--- a/vibe_core/phoenix/config.py
+++ b/vibe_core/phoenix/config.py
@@ -14,6 +14,7 @@ import yaml
 from .sections.circuits import CircuitConfig, discover_circuits
 from .sections.city import CityConfig
 from .sections.kernel import KernelConfig
+from .sections.quality import QualityConfig, get_default_quality_config
 from .sections.routing import RoutingRule, load_routing_rules, save_routing_rules
 
 logger = logging.getLogger(__name__)
@@ -35,12 +36,14 @@ class PhoenixConfig:
     city: CityConfig = field(default_factory=CityConfig)
     circuits: Dict[str, CircuitConfig] = field(default_factory=dict)
     routing: List[RoutingRule] = field(default_factory=list)
+    quality: QualityConfig = field(default_factory=get_default_quality_config)
 
     # Source file paths (for save/reload)
     _phoenix_path: Optional[Path] = field(default=None, repr=False)
     _matrix_path: Optional[Path] = field(default=None, repr=False)
     _circuits_dir: Optional[Path] = field(default=None, repr=False)
     _routing_path: Optional[Path] = field(default=None, repr=False)
+    _quality_path: Optional[Path] = field(default=None, repr=False)
 
     @classmethod
     def from_files(
@@ -49,6 +52,7 @@ class PhoenixConfig:
         matrix_path: Path = Path("config/matrix.yaml"),
         circuits_dir: Path = Path("vibe_core/playbook/circuits"),
         routing_path: Path = Path("MATRIX.md"),
+        quality_path: Path = Path("config/quality.yaml"),
     ) -> "PhoenixConfig":
         """
         Load configuration from all source files.
@@ -58,6 +62,7 @@ class PhoenixConfig:
             matrix_path: Path to matrix.yaml (city config)
             circuits_dir: Directory containing circuit YAML files
             routing_path: Path to MATRIX.md (routing rules)
+            quality_path: Path to quality.yaml (lint/format/CI config)
 
         Returns:
             Fully loaded PhoenixConfig
@@ -92,11 +97,23 @@ class PhoenixConfig:
         routing = load_routing_rules(routing_path)
         logger.info(f"Loaded {len(routing)} routing rules from {routing_path}")
 
+        # Load quality config (immortal CI/lint settings)
+        quality = get_default_quality_config()
+        if quality_path.exists():
+            try:
+                with open(quality_path) as f:
+                    data = yaml.safe_load(f) or {}
+                quality = QualityConfig.from_dict(data)
+                logger.info(f"Loaded quality config from {quality_path}")
+            except Exception as e:
+                logger.warning(f"Failed to load {quality_path}, using defaults: {e}")
+
         config = cls(
             kernel=kernel,
             city=city,
             circuits=circuits,
             routing=routing,
+            quality=quality,
         )
 
         # Store paths for later save/reload
@@ -104,6 +121,7 @@ class PhoenixConfig:
         config._matrix_path = matrix_path
         config._circuits_dir = circuits_dir
         config._routing_path = routing_path
+        config._quality_path = quality_path
 
         return config
 
@@ -301,6 +319,7 @@ class PhoenixConfig:
             "city": self.city.to_dict(),
             "circuits": {name: circuit.to_dict() for name, circuit in self.circuits.items()},
             "routing": [rule.to_dict() for rule in self.routing],
+            "quality": self.quality.to_dict(),
         }
 
     @classmethod
@@ -327,11 +346,14 @@ class PhoenixConfig:
         for rule_data in data.get("routing", []):
             routing.append(RoutingRule.from_dict(rule_data))
 
+        quality = QualityConfig.from_dict(data.get("quality", {}))
+
         return cls(
             kernel=kernel,
             city=city,
             circuits=circuits,
             routing=routing,
+            quality=quality,
         )
 
     # =========================================================================

--- a/vibe_core/phoenix/sections/__init__.py
+++ b/vibe_core/phoenix/sections/__init__.py
@@ -3,6 +3,14 @@
 from .circuits import CircuitConfig
 from .city import AgentsConfig, CityConfig, EconomyConfig, GovernanceConfig
 from .kernel import FeaturesConfig, KernelConfig, ProviderConfig, SystemConfig
+from .quality import (
+    CIConfig,
+    CIWorkflow,
+    FormatConfig,
+    LintConfig,
+    QualityConfig,
+    TestConfig,
+)
 from .routing import RoutingRule
 
 __all__ = [
@@ -16,6 +24,13 @@ __all__ = [
     "GovernanceConfig",
     "EconomyConfig",
     "AgentsConfig",
+    # Quality (immortal CI/lint config)
+    "QualityConfig",
+    "LintConfig",
+    "FormatConfig",
+    "TestConfig",
+    "CIConfig",
+    "CIWorkflow",
     # Dynamic
     "CircuitConfig",
     "RoutingRule",

--- a/vibe_core/phoenix/sections/quality.py
+++ b/vibe_core/phoenix/sections/quality.py
@@ -1,0 +1,291 @@
+"""Quality Configuration - Lint, Format, CI settings.
+
+This config is IMMORTAL - lives in repo, survives container wipes.
+Pre-commit hooks, CI workflows, lint rules - all defined here.
+
+Philosophy:
+- Container gets wiped? Config survives.
+- New developer joins? Config tells them what to enforce.
+- Agent needs to check code? Config defines the rules.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class LintConfig:
+    """Linter configuration (ruff)."""
+
+    tool: str = "ruff"
+    # Critical rules that MUST pass (CI fails on these)
+    critical_rules: List[str] = field(default_factory=lambda: ["E9", "F63", "F7", "F82"])
+    # Info rules (shown but don't fail CI)
+    info_rules: List[str] = field(default_factory=lambda: ["E", "F", "I", "W"])
+    # Paths to check
+    paths: List[str] = field(default_factory=lambda: ["vibe_core", "steward", "scripts"])
+    # Paths to exclude
+    exclude: List[str] = field(
+        default_factory=lambda: [
+            ".git",
+            ".venv",
+            "__pycache__",
+            "data",
+            "archive",
+            "node_modules",
+        ]
+    )
+    # Line length limit
+    line_length: int = 120
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "critical_rules": self.critical_rules,
+            "info_rules": self.info_rules,
+            "paths": self.paths,
+            "exclude": self.exclude,
+            "line_length": self.line_length,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LintConfig":
+        return cls(
+            tool=data.get("tool", "ruff"),
+            critical_rules=data.get("critical_rules", ["E9", "F63", "F7", "F82"]),
+            info_rules=data.get("info_rules", ["E", "F", "I", "W"]),
+            paths=data.get("paths", ["vibe_core", "steward", "scripts"]),
+            exclude=data.get("exclude", []),
+            line_length=data.get("line_length", 120),
+        )
+
+
+@dataclass
+class FormatConfig:
+    """Formatter configuration (ruff format)."""
+
+    tool: str = "ruff"
+    # Auto-fix on commit?
+    auto_fix: bool = True
+    # Paths to format
+    paths: List[str] = field(default_factory=lambda: ["vibe_core", "steward", "scripts"])
+    # Line length
+    line_length: int = 120
+    # Quote style
+    quote_style: str = "double"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "auto_fix": self.auto_fix,
+            "paths": self.paths,
+            "line_length": self.line_length,
+            "quote_style": self.quote_style,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FormatConfig":
+        return cls(
+            tool=data.get("tool", "ruff"),
+            auto_fix=data.get("auto_fix", True),
+            paths=data.get("paths", ["vibe_core", "steward", "scripts"]),
+            line_length=data.get("line_length", 120),
+            quote_style=data.get("quote_style", "double"),
+        )
+
+
+@dataclass
+class TestConfig:
+    """Test runner configuration."""
+
+    tool: str = "pytest"
+    paths: List[str] = field(default_factory=lambda: ["tests"])
+    # Markers to run by default
+    default_markers: List[str] = field(default_factory=list)
+    # Timeout per test (seconds)
+    timeout: int = 300
+    # Parallel workers (0 = auto)
+    workers: int = 0
+    # Coverage threshold (0 = disabled)
+    coverage_threshold: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "paths": self.paths,
+            "default_markers": self.default_markers,
+            "timeout": self.timeout,
+            "workers": self.workers,
+            "coverage_threshold": self.coverage_threshold,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TestConfig":
+        return cls(
+            tool=data.get("tool", "pytest"),
+            paths=data.get("paths", ["tests"]),
+            default_markers=data.get("default_markers", []),
+            timeout=data.get("timeout", 300),
+            workers=data.get("workers", 0),
+            coverage_threshold=data.get("coverage_threshold", 0),
+        )
+
+
+@dataclass
+class CIWorkflow:
+    """Single CI workflow definition."""
+
+    name: str
+    file: str
+    triggers: List[str] = field(default_factory=lambda: ["push", "pull_request"])
+    required: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "file": self.file,
+            "triggers": self.triggers,
+            "required": self.required,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CIWorkflow":
+        return cls(
+            name=data.get("name", ""),
+            file=data.get("file", ""),
+            triggers=data.get("triggers", ["push", "pull_request"]),
+            required=data.get("required", True),
+        )
+
+
+@dataclass
+class CIConfig:
+    """CI/CD configuration."""
+
+    # Primary workflows
+    workflows: List[CIWorkflow] = field(default_factory=list)
+    # Protected branches
+    protected_branches: List[str] = field(default_factory=lambda: ["main", "master"])
+    # Require status checks before merge
+    require_status_checks: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "workflows": [w.to_dict() for w in self.workflows],
+            "protected_branches": self.protected_branches,
+            "require_status_checks": self.require_status_checks,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CIConfig":
+        workflows = [CIWorkflow.from_dict(w) for w in data.get("workflows", [])]
+        return cls(
+            workflows=workflows,
+            protected_branches=data.get("protected_branches", ["main", "master"]),
+            require_status_checks=data.get("require_status_checks", True),
+        )
+
+
+@dataclass
+class QualityConfig:
+    """
+    Complete quality configuration.
+
+    This is the SINGLE SOURCE OF TRUTH for:
+    - Lint rules
+    - Format rules
+    - Test configuration
+    - CI workflows
+
+    Why here and not in .pre-commit-config.yaml?
+    - That file dies with container wipe
+    - This config lives in repo forever (phoenix = immortal)
+    - Agents can read this to understand quality requirements
+    - Kernel can enforce these rules
+    """
+
+    lint: LintConfig = field(default_factory=LintConfig)
+    format: FormatConfig = field(default_factory=FormatConfig)
+    test: TestConfig = field(default_factory=TestConfig)
+    ci: CIConfig = field(default_factory=CIConfig)
+
+    # Enforcement flags
+    enforce_on_commit: bool = True
+    enforce_on_push: bool = True
+    block_on_failure: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "lint": self.lint.to_dict(),
+            "format": self.format.to_dict(),
+            "test": self.test.to_dict(),
+            "ci": self.ci.to_dict(),
+            "enforce_on_commit": self.enforce_on_commit,
+            "enforce_on_push": self.enforce_on_push,
+            "block_on_failure": self.block_on_failure,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "QualityConfig":
+        return cls(
+            lint=LintConfig.from_dict(data.get("lint", {})),
+            format=FormatConfig.from_dict(data.get("format", {})),
+            test=TestConfig.from_dict(data.get("test", {})),
+            ci=CIConfig.from_dict(data.get("ci", {})),
+            enforce_on_commit=data.get("enforce_on_commit", True),
+            enforce_on_push=data.get("enforce_on_push", True),
+            block_on_failure=data.get("block_on_failure", True),
+        )
+
+    def get_ruff_critical_args(self) -> List[str]:
+        """Get ruff args for critical-only check (CI mode)."""
+        rules = ",".join(self.lint.critical_rules)
+        return [f"--select={rules}"] + self.lint.paths
+
+    def get_ruff_full_args(self) -> List[str]:
+        """Get ruff args for full check (informational)."""
+        rules = ",".join(self.lint.info_rules)
+        return [f"--select={rules}", "--statistics"] + self.lint.paths
+
+    def get_pytest_args(self) -> List[str]:
+        """Get pytest args from config."""
+        args = self.test.paths.copy()
+        if self.test.timeout:
+            args.extend(["--timeout", str(self.test.timeout)])
+        if self.test.workers:
+            args.extend(["-n", str(self.test.workers)])
+        if self.test.coverage_threshold:
+            args.extend(["--cov", "--cov-fail-under", str(self.test.coverage_threshold)])
+        return args
+
+
+# Default quality config with steward-protocol settings
+def get_default_quality_config() -> QualityConfig:
+    """Get default quality config matching current CI setup."""
+    return QualityConfig(
+        lint=LintConfig(
+            tool="ruff",
+            critical_rules=["E9", "F63", "F7", "F82"],
+            info_rules=["E", "F", "I", "W"],
+            paths=["vibe_core", "steward", "scripts"],
+            line_length=120,
+        ),
+        format=FormatConfig(
+            tool="ruff",
+            auto_fix=True,
+            paths=["vibe_core", "steward", "scripts"],
+            line_length=120,
+        ),
+        test=TestConfig(
+            tool="pytest",
+            paths=["tests"],
+            timeout=300,
+        ),
+        ci=CIConfig(
+            workflows=[
+                CIWorkflow(name="Lint & Format", file="steward-ci.yml", required=True),
+                CIWorkflow(name="Integration Tests", file="integration-tests.yml", required=True),
+            ],
+            protected_branches=["main", "master"],
+        ),
+    )


### PR DESCRIPTION
This makes lint rules, format config, test settings, and CI workflows part of the immortal Phoenix configuration that survives container wipes.

New files:
- vibe_core/phoenix/sections/quality.py - QualityConfig dataclasses
- config/quality.yaml - Source of truth for quality settings

Structure:
```
PhoenixConfig
├── kernel: KernelConfig
├── city: CityConfig
├── circuits: Dict[str, CircuitConfig]
├── routing: List[RoutingRule]
└── quality: QualityConfig  ← NEW
    ├── lint: LintConfig (ruff rules, paths)
    ├── format: FormatConfig (ruff format settings)
    ├── test: TestConfig (pytest settings)
    └── ci: CIConfig (workflow definitions)
```

Why:
- Container wipe kills pre-commit install
- Phoenix config lives in repo forever
- Agents can read quality.lint to understand rules
- Single source of truth for CI and local checks

Usage:
```python
config = get_config()
ruff_args = config.quality.get_ruff_critical_args()
pytest_args = config.quality.get_pytest_args()
```

All 374 tests pass.