### PR TITLE
feat: Add Test Governance - Who Watches the Watchers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # 📋 Mission Control
 
-> **Auto-Generated Task Board** | Last Updated: 2025-12-05 18:16:41
+> **Auto-Generated Task Board** | Last Updated: 2025-12-05 19:35:49
 > **Status:** 🟢 Operational | **Active Tasks:** 0 | **Completed:** 45
 
 ---
@@ -30,19 +30,19 @@ No active missions yet.
 ## ✅ Recently Completed
 
 - [x] Routine security patrol @watchman
-  > *Completed: 2025-12-05 18:16*
+  > *Completed: 2025-12-05 19:34*
 
 - [x] Update constitutional amendment @civic
-  > *Completed: 2025-12-05 18:16*
+  > *Completed: 2025-12-05 19:34*
 
 - [x] CRITICAL: System down emergency @auto-routed
-  > *Completed: 2025-12-05 18:16*
+  > *Completed: 2025-12-05 19:34*
 
 - [x] Content generation - HERALD @herald
-  > *Completed: 2025-12-05 18:16*
+  > *Completed: 2025-12-05 19:34*
 
 - [x] Security patrol - WATCHMAN @watchman
-  > *Completed: 2025-12-05 18:16*
+  > *Completed: 2025-12-05 19:34*
 
 ---
 
@@ -50,8 +50,8 @@ No active missions yet.
 
 | Metric | Value |
 |--------|-------|
-| Total Tasks | 49 |
-| Pending | 4 |
+| Total Tasks | 50 |
+| Pending | 5 |
 | Running | 0 |
 | Completed | 45 |
 | Blocked | 0 |
@@ -59,7 +59,7 @@ No active missions yet.
 ---
 
 **Heartbeat:** Operational  
-**Last Pulse:** 2025-12-05 18:16:41 UTC  
+**Last Pulse:** 2025-12-05 19:35:49 UTC  
 **Next Check:** ~15 minutes
 
 ---

--- a/config/test_governance.yaml
+++ b/config/test_governance.yaml
@@ -1,0 +1,108 @@
+# ============================================================================
+# TEST GOVERNANCE - Who Watches the Watchers
+# ============================================================================
+#
+# This configuration controls how the test suite is protected from
+# silent mutations that could hide regressions.
+#
+# PHILOSOPHY:
+# Tests are CONTRACTS. When a test fails, the CODE is wrong, not the test.
+# AI agents are forbidden from modifying tests to make them pass.
+#
+# ============================================================================
+
+---
+
+# ========================================================================
+# MUTATION POLICY
+# ========================================================================
+# What happens when AI attempts to modify a test file?
+#
+# Options:
+#   - blocked: Modification is rejected entirely (RECOMMENDED)
+#   - human_approval: Requires explicit human approval via prompt
+#   - warn_only: Log warning but allow (DANGEROUS - use only for debugging)
+#
+mutation_policy: "blocked"
+
+
+# ========================================================================
+# BASELINE ENFORCEMENT
+# ========================================================================
+# If true, test file hashes are recorded in lineage.
+# Any mutation since "birth" is detected and flagged.
+#
+baseline_enforcement: true
+baseline_path: "data/test_baselines.json"
+
+
+# ========================================================================
+# REGRESSION MODE
+# ========================================================================
+# When a test fails, what should AI do?
+#
+# Options:
+#   - fix_code_not_test: AI MUST fix the implementation (RECOMMENDED)
+#   - allow_test_updates: AI can update tests (DANGEROUS)
+#
+regression_mode: "fix_code_not_test"
+
+
+# ========================================================================
+# FROZEN TESTS (CONSTITUTIONAL)
+# ========================================================================
+# These tests can NEVER be modified by AI, period.
+# They are the "constitution" of the test suite.
+#
+frozen_tests:
+  # Core integration tests
+  - "tests/integration/test_system_boot.py"
+  - "tests/test_unified_loader.py"
+
+  # Security/hardening tests
+  - "tests/hardening/**"
+  - "tests/test_crypto_verification.py"
+
+  # Lifecycle tests (contract enforcement)
+  - "tests/test_lifecycle_*.py"
+
+
+# ========================================================================
+# HUMAN REVIEW REQUIRED
+# ========================================================================
+# Any change to these patterns requires explicit human review.
+# By default, ALL tests require human review.
+#
+human_review_required_patterns:
+  - "tests/**"
+
+
+# ========================================================================
+# AUDIT SETTINGS
+# ========================================================================
+# Track every attempt to modify tests.
+#
+log_all_test_mutations: true
+mutation_log_path: "data/logs/test_mutations.log"
+alert_on_mutation_attempt: true
+
+
+# ========================================================================
+# NOTES
+# ========================================================================
+notes: |
+  TEST GOVERNANCE ensures the integrity of the test suite.
+
+  PROBLEM SOLVED:
+  1. AI writes a test for feature X
+  2. Code changes break the test
+  3. AI "fixes" the test instead of the code
+  4. Regression goes unnoticed!
+
+  SOLUTION:
+  - Tests are immutable contracts
+  - Hash of each test recorded at "birth"
+  - Mutations are blocked or require human approval
+  - When test fails, AI MUST fix CODE, not test
+
+  This is "who watches the watchers" - the lineage watches the tests.

--- a/docs/architecture/OPUS_UNIFIED_LOADER.md
+++ b/docs/architecture/OPUS_UNIFIED_LOADER.md
@@ -79,10 +79,16 @@ class AgentLoader(UnifiedLoader):
 - [x] All 29 unified loader tests pass
 - [x] Kernel boots correctly with all sections
 
-### Phase 4: Cleanup
-- [ ] Remove duplicate code from old loaders
-- [ ] Update documentation
-- [ ] Final test run
+### Phase 4: Cleanup ✅ COMPLETE
+- [x] PR #308 created for main branch
+- [x] Old-style plugin .py files removed
+- [x] Documentation updated
+
+### Phase 5: Remaining Loaders (FUTURE)
+- [ ] WorkflowLoader → UnifiedLoader
+- [ ] PlaybookLoader → UnifiedLoader
+- [ ] KnowledgeLoader → UnifiedLoader
+- [ ] ContextLoader → UnifiedLoader
 
 ---
 

--- a/vibe_core/phoenix/sections/test_governance/__init__.py
+++ b/vibe_core/phoenix/sections/test_governance/__init__.py
@@ -1,0 +1,5 @@
+"""Test Governance Config Section."""
+
+from .section_main import TestGovernanceConfig
+
+__all__ = ["TestGovernanceConfig"]

--- a/vibe_core/phoenix/sections/test_governance/manifest.json
+++ b/vibe_core/phoenix/sections/test_governance/manifest.json
@@ -1,0 +1,45 @@
+{
+  "type": "section",
+  "id": "test_governance",
+  "name": "Test Governance Configuration",
+  "version": "1.0.0",
+  "description": "WHO WATCHES THE WATCHERS - Test suite immutability and governance",
+
+  "entry_point": "section_main.py",
+  "entry_class": "TestGovernanceConfig",
+
+  "priority": 5,
+
+  "config_file": "config/test_governance.yaml",
+
+  "author": "STEWARD Protocol",
+  "tags": ["config", "testing", "governance", "security"],
+
+  "schema": {
+    "mutation_policy": {
+      "type": "string",
+      "enum": ["blocked", "human_approval", "warn_only"],
+      "default": "blocked",
+      "description": "What happens when AI tries to modify a test"
+    },
+    "baseline_enforcement": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enforce test contract hashes from lineage"
+    },
+    "regression_mode": {
+      "type": "string",
+      "enum": ["fix_code_not_test", "allow_test_updates"],
+      "default": "fix_code_not_test",
+      "description": "When test fails: AI must fix CODE, not test"
+    },
+    "frozen_tests": {
+      "type": "array",
+      "description": "Glob patterns for tests that can NEVER be modified"
+    },
+    "human_review_required_patterns": {
+      "type": "array",
+      "description": "Glob patterns requiring human review for any change"
+    }
+  }
+}

--- a/vibe_core/phoenix/sections/test_governance/section_main.py
+++ b/vibe_core/phoenix/sections/test_governance/section_main.py
@@ -1,0 +1,182 @@
+"""
+TEST GOVERNANCE CONFIG SECTION - Who Watches the Watchers
+
+PROBLEM:
+- AI writes test
+- Code changes
+- Test fails
+- AI changes test to pass  <-- REGRESSION! Contract broken!
+- Nobody notices
+
+SOLUTION:
+- Tests are IMMUTABLE CONTRACTS
+- Hash of each test stored in lineage at "birth"
+- Mutation attempts are BLOCKED (or require human approval)
+- Regression = AI must fix CODE, not test!
+
+This config section controls test governance policy.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+# Phoenix section marker
+section_id = "test_governance"
+
+
+@dataclass
+class TestGovernanceConfig:
+    """
+    Configuration for test suite governance.
+
+    This is the "watchman's watchman" - ensures tests can't be
+    silently modified to hide regressions.
+    """
+
+    # ========================================================================
+    # MUTATION POLICY
+    # ========================================================================
+
+    mutation_policy: str = "blocked"
+    """
+    What happens when AI attempts to modify a test file:
+    - "blocked": Modification is rejected entirely
+    - "human_approval": Requires explicit human approval
+    - "warn_only": Log warning but allow (dangerous!)
+    """
+
+    # ========================================================================
+    # BASELINE ENFORCEMENT
+    # ========================================================================
+
+    baseline_enforcement: bool = True
+    """
+    If True, compare test file hashes against lineage records.
+    Tests that have mutated since their "birth" are flagged.
+    """
+
+    baseline_path: str = "data/test_baselines.json"
+    """Path to store test baseline hashes."""
+
+    # ========================================================================
+    # REGRESSION MODE
+    # ========================================================================
+
+    regression_mode: str = "fix_code_not_test"
+    """
+    When a test fails, what should AI do?
+    - "fix_code_not_test": AI MUST fix the implementation, not the test
+    - "allow_test_updates": AI can update tests (dangerous!)
+    """
+
+    # ========================================================================
+    # FROZEN PATTERNS
+    # ========================================================================
+
+    frozen_tests: List[str] = field(
+        default_factory=lambda: [
+            "tests/integration/test_system_boot.py",
+            "tests/test_unified_loader.py",
+            "tests/hardening/**",
+        ]
+    )
+    """
+    Glob patterns for tests that can NEVER be modified by AI.
+    These are the "constitutional tests" - the foundation.
+    """
+
+    human_review_required_patterns: List[str] = field(
+        default_factory=lambda: [
+            "tests/**",  # All tests require human review by default
+        ]
+    )
+    """
+    Glob patterns for tests that require human review for ANY change.
+    """
+
+    # ========================================================================
+    # AUDIT SETTINGS
+    # ========================================================================
+
+    log_all_test_mutations: bool = True
+    """Log every attempt to modify a test file."""
+
+    mutation_log_path: str = "data/logs/test_mutations.log"
+    """Path for test mutation audit log."""
+
+    alert_on_mutation_attempt: bool = True
+    """Raise visible alert when mutation is attempted."""
+
+    # ========================================================================
+    # SERIALIZATION (required for SectionLoader)
+    # ========================================================================
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TestGovernanceConfig":
+        """Create from parsed YAML dict."""
+        return cls(
+            mutation_policy=data.get("mutation_policy", "blocked"),
+            baseline_enforcement=data.get("baseline_enforcement", True),
+            baseline_path=data.get("baseline_path", "data/test_baselines.json"),
+            regression_mode=data.get("regression_mode", "fix_code_not_test"),
+            frozen_tests=data.get(
+                "frozen_tests",
+                [
+                    "tests/integration/test_system_boot.py",
+                    "tests/test_unified_loader.py",
+                    "tests/hardening/**",
+                ],
+            ),
+            human_review_required_patterns=data.get("human_review_required_patterns", ["tests/**"]),
+            log_all_test_mutations=data.get("log_all_test_mutations", True),
+            mutation_log_path=data.get("mutation_log_path", "data/logs/test_mutations.log"),
+            alert_on_mutation_attempt=data.get("alert_on_mutation_attempt", True),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to YAML-compatible dict."""
+        return {
+            "mutation_policy": self.mutation_policy,
+            "baseline_enforcement": self.baseline_enforcement,
+            "baseline_path": self.baseline_path,
+            "regression_mode": self.regression_mode,
+            "frozen_tests": self.frozen_tests,
+            "human_review_required_patterns": self.human_review_required_patterns,
+            "log_all_test_mutations": self.log_all_test_mutations,
+            "mutation_log_path": self.mutation_log_path,
+            "alert_on_mutation_attempt": self.alert_on_mutation_attempt,
+        }
+
+    # ========================================================================
+    # VALIDATION
+    # ========================================================================
+
+    def validate(self) -> bool:
+        """Validate configuration."""
+        valid_policies = ["blocked", "human_approval", "warn_only"]
+        if self.mutation_policy not in valid_policies:
+            raise ValueError(f"mutation_policy must be one of {valid_policies}")
+
+        valid_modes = ["fix_code_not_test", "allow_test_updates"]
+        if self.regression_mode not in valid_modes:
+            raise ValueError(f"regression_mode must be one of {valid_modes}")
+
+        return True
+
+    def is_frozen(self, test_path: str) -> bool:
+        """Check if a test file is frozen (can never be modified)."""
+        from fnmatch import fnmatch
+
+        for pattern in self.frozen_tests:
+            if fnmatch(test_path, pattern):
+                return True
+        return False
+
+    def requires_human_review(self, test_path: str) -> bool:
+        """Check if a test file requires human review for changes."""
+        from fnmatch import fnmatch
+
+        for pattern in self.human_review_required_patterns:
+            if fnmatch(test_path, pattern):
+                return True
+        return False

--- a/vibe_core/plugins/test_orchestration/plugin_main.py
+++ b/vibe_core/plugins/test_orchestration/plugin_main.py
@@ -4,6 +4,7 @@ UNIVERSAL TEST ORCHESTRATION PLUGIN - Tests for ALL Components
 PHILOSOPHY:
 "The observer must be part of the observed system."
 "Every component knows its own tests." - Fractal Testing Principle
+"Quis custodiet ipsos custodes?" - Who watches the watchers?
 
 This plugin auto-discovers and tests ALL component types:
 - Agents (34+)
@@ -13,6 +14,11 @@ This plugin auto-discovers and tests ALL component types:
 - Core Infrastructure (Ledger, Scheduler, EventBus)
 - Governance Components
 - Runtime Components
+
+TEST GOVERNANCE:
+Tests are IMMUTABLE CONTRACTS. When a test fails, the CODE is wrong.
+AI agents are BLOCKED from modifying tests to make them pass.
+The TestGuardian enforces this policy via lineage-recorded contracts.
 """
 
 import logging
@@ -104,6 +110,10 @@ class TestOrchestrationPlugin(KernelPlugin):
     Uses the Testable protocol for component-aware test generation.
     Each component knows its own tests (fractal design).
 
+    TEST GOVERNANCE:
+    Includes TestGuardian for test immutability enforcement.
+    Tests are contracts - AI cannot modify them to hide regressions.
+
     Priority: 200 (runs after all other plugins)
     """
 
@@ -112,6 +122,7 @@ class TestOrchestrationPlugin(KernelPlugin):
         self._results: List[TestResult] = []
         self._kernel: Optional["RealVibeKernel"] = None
         self._discovery_counts: Dict[str, int] = {}
+        self._guardian = None  # Lazy-loaded TestGuardian
 
     @property
     def plugin_id(self) -> str:
@@ -416,3 +427,37 @@ class TestOrchestrationPlugin(KernelPlugin):
             )
 
         return result
+
+    # ========================================================================
+    # TEST GUARDIAN INTEGRATION
+    # ========================================================================
+
+    @property
+    def guardian(self):
+        """Get or create the TestGuardian instance."""
+        if self._guardian is None:
+            from vibe_core.plugins.test_orchestration.test_guardian import TestGuardian
+
+            self._guardian = TestGuardian(self._kernel)
+        return self._guardian
+
+    def validate_tests_before_run(self, test_path: str = "tests") -> Dict[str, Any]:
+        """
+        Validate all tests haven't mutated before running them.
+
+        This is the "who watches the watchers" check.
+        Returns validation results.
+        """
+        return self.guardian.validate_all_tests(test_path)
+
+    def can_modify_test(self, test_path: str, modifier: str = "ai") -> tuple[bool, str]:
+        """
+        Check if a test file can be modified.
+
+        Used by IDE hooks and commit hooks to block unauthorized changes.
+        """
+        return self.guardian.can_modify(test_path, modifier)
+
+    def get_guardian_status(self) -> str:
+        """Get human-readable status of test governance."""
+        return self.guardian.print_status()

--- a/vibe_core/plugins/test_orchestration/test_guardian.py
+++ b/vibe_core/plugins/test_orchestration/test_guardian.py
@@ -1,0 +1,541 @@
+"""
+TEST GUARDIAN - Who Watches the Watchers
+
+PHILOSOPHY:
+"Quis custodiet ipsos custodes?" - Who will guard the guards themselves?
+
+Tests are CONTRACTS. They define expected behavior.
+When code changes break a test, the CODE is wrong, not the test.
+
+This module enforces test immutability:
+1. Records test hashes at "birth" (first run)
+2. Detects mutations before test execution
+3. Blocks or alerts on unauthorized changes
+4. Logs all mutation attempts to lineage
+
+INTEGRATION:
+- Reads policy from TestGovernanceConfig (Phoenix section)
+- Records baselines to lineage (immutable)
+- Called by TestOrchestrationPlugin before running tests
+"""
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from vibe_core.kernel_impl import RealVibeKernel
+
+logger = logging.getLogger("TEST_GUARDIAN")
+
+
+# ============================================================================
+# TEST CONTRACT - Immutable record of a test's "birth"
+# ============================================================================
+
+
+@dataclass
+class TestContract:
+    """
+    Immutable record of a test file at its creation.
+
+    Once a test is "born", its hash is recorded.
+    Any future mutation triggers governance policy.
+    """
+
+    test_path: str
+    content_hash: str
+    created_at: str
+    created_by: str = "unknown"
+    frozen: bool = False
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "test_path": self.test_path,
+            "content_hash": self.content_hash,
+            "created_at": self.created_at,
+            "created_by": self.created_by,
+            "frozen": self.frozen,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TestContract":
+        return cls(**data)
+
+
+# ============================================================================
+# MUTATION EVENT - Record of an attempted/detected mutation
+# ============================================================================
+
+
+@dataclass
+class MutationEvent:
+    """Record of a detected test mutation."""
+
+    test_path: str
+    old_hash: str
+    new_hash: str
+    detected_at: str
+    action_taken: str  # "blocked", "approved", "warned"
+    approved_by: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "test_path": self.test_path,
+            "old_hash": self.old_hash,
+            "new_hash": self.new_hash,
+            "detected_at": self.detected_at,
+            "action_taken": self.action_taken,
+            "approved_by": self.approved_by,
+        }
+
+
+# ============================================================================
+# TEST GUARDIAN - The Watchman
+# ============================================================================
+
+
+class TestGuardian:
+    """
+    Guardian of test suite integrity.
+
+    Enforces test immutability policy:
+    - Records test hashes at first run ("birth")
+    - Detects mutations before execution
+    - Blocks/warns/requires approval based on policy
+    - Logs everything to lineage
+    """
+
+    def __init__(self, kernel: Optional["RealVibeKernel"] = None):
+        self._kernel = kernel
+        self._contracts: Dict[str, TestContract] = {}
+        self._mutations: List[MutationEvent] = []
+        self._config = None
+
+        # Temporary permits for test updates (expire after one use)
+        self._update_permits: Dict[str, str] = {}  # test_path -> reason
+
+        # Load existing baselines
+        self._load_baselines()
+
+    def _get_config(self):
+        """Get TestGovernanceConfig from Phoenix."""
+        if self._config is not None:
+            return self._config
+
+        # Try to get from kernel's Phoenix config
+        if self._kernel and hasattr(self._kernel, "config"):
+            config = getattr(self._kernel.config, "test_governance", None)
+            if config:
+                self._config = config
+                return self._config
+
+        # Fallback to defaults
+        from vibe_core.phoenix.sections.test_governance.section_main import (
+            TestGovernanceConfig,
+        )
+
+        self._config = TestGovernanceConfig()
+        return self._config
+
+    def _get_baseline_path(self) -> Path:
+        """Get path to baseline storage."""
+        config = self._get_config()
+        return Path(config.baseline_path)
+
+    def _load_baselines(self) -> None:
+        """Load existing test contracts from disk."""
+        path = self._get_baseline_path()
+        if path.exists():
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+                for test_path, contract_data in data.get("contracts", {}).items():
+                    self._contracts[test_path] = TestContract.from_dict(contract_data)
+                logger.info(f"Loaded {len(self._contracts)} test contracts")
+            except Exception as e:
+                logger.warning(f"Failed to load baselines: {e}")
+
+    def _save_baselines(self) -> None:
+        """Save test contracts to disk."""
+        path = self._get_baseline_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "version": "1.0.0",
+            "updated_at": datetime.now().isoformat(),
+            "contracts": {k: v.to_dict() for k, v in self._contracts.items()},
+        }
+
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+    # ========================================================================
+    # CORE API
+    # ========================================================================
+
+    def hash_file(self, path: Path) -> str:
+        """Compute SHA-256 hash of a file."""
+        if not path.exists():
+            return "FILE_NOT_FOUND"
+
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()[:16]
+
+    def register_test(
+        self,
+        test_path: str,
+        created_by: str = "unknown",
+        frozen: bool = False,
+    ) -> TestContract:
+        """
+        Register a new test contract (at "birth").
+
+        This records the test's hash, making it immutable.
+        """
+        path = Path(test_path)
+        content_hash = self.hash_file(path)
+
+        contract = TestContract(
+            test_path=test_path,
+            content_hash=content_hash,
+            created_at=datetime.now().isoformat(),
+            created_by=created_by,
+            frozen=frozen,
+        )
+
+        self._contracts[test_path] = contract
+        self._save_baselines()
+
+        # Record to lineage
+        self._record_to_lineage(
+            event_type="TEST_CONTRACT_CREATED",
+            details={
+                "test_path": test_path,
+                "content_hash": content_hash,
+                "frozen": frozen,
+            },
+        )
+
+        logger.info(f"Registered test contract: {test_path} ({content_hash})")
+        return contract
+
+    def validate_test(self, test_path: str) -> tuple[bool, Optional[str]]:
+        """
+        Validate a test file hasn't mutated.
+
+        Returns:
+            (is_valid, error_message)
+            is_valid: True if test is unchanged or no contract exists
+            error_message: Description of mutation if detected
+        """
+        config = self._get_config()
+
+        # Check if we have a contract for this test
+        if test_path not in self._contracts:
+            # No contract = first run, register it
+            if config.baseline_enforcement:
+                self.register_test(test_path)
+            return (True, None)
+
+        # Compare current hash with contract
+        contract = self._contracts[test_path]
+        current_hash = self.hash_file(Path(test_path))
+
+        if current_hash == contract.content_hash:
+            return (True, None)
+
+        # MUTATION DETECTED!
+        error = f"Test mutation detected: {test_path}"
+        error += f"\n  Original: {contract.content_hash}"
+        error += f"\n  Current:  {current_hash}"
+
+        # Log the mutation
+        mutation = MutationEvent(
+            test_path=test_path,
+            old_hash=contract.content_hash,
+            new_hash=current_hash,
+            detected_at=datetime.now().isoformat(),
+            action_taken=config.mutation_policy,
+        )
+        self._mutations.append(mutation)
+
+        # Record to lineage
+        self._record_to_lineage(
+            event_type="TEST_MUTATION_DETECTED",
+            details=mutation.to_dict(),
+        )
+
+        # Apply policy
+        if config.mutation_policy == "blocked":
+            logger.error(f"BLOCKED: {error}")
+            return (False, error)
+        elif config.mutation_policy == "human_approval":
+            logger.warning(f"REQUIRES APPROVAL: {error}")
+            return (False, error + "\n\nHuman approval required to proceed.")
+        else:  # warn_only
+            logger.warning(f"WARNING: {error}")
+            return (True, None)
+
+    def validate_all_tests(self, test_dir: str = "tests") -> Dict[str, Any]:
+        """
+        Validate all test files in a directory.
+
+        Returns summary of validation results.
+        """
+        results = {
+            "total": 0,
+            "valid": 0,
+            "mutated": 0,
+            "new": 0,
+            "errors": [],
+        }
+
+        test_path = Path(test_dir)
+        for py_file in test_path.rglob("test_*.py"):
+            results["total"] += 1
+            rel_path = str(py_file)
+
+            if rel_path not in self._contracts:
+                results["new"] += 1
+                self.register_test(rel_path)
+            else:
+                is_valid, error = self.validate_test(rel_path)
+                if is_valid:
+                    results["valid"] += 1
+                else:
+                    results["mutated"] += 1
+                    results["errors"].append(error)
+
+        return results
+
+    def is_frozen(self, test_path: str) -> bool:
+        """Check if a test is frozen (can never be modified)."""
+        config = self._get_config()
+        return config.is_frozen(test_path)
+
+    def can_modify(self, test_path: str, modifier: str = "ai") -> tuple[bool, str]:
+        """
+        Check if a test can be modified.
+
+        Returns:
+            (can_modify, reason)
+        """
+        config = self._get_config()
+
+        # Check if frozen (CONSTITUTIONAL - never modifiable)
+        if self.is_frozen(test_path):
+            return (False, f"Test is FROZEN and cannot be modified: {test_path}")
+
+        # Check for temporary permit (Feature Evolution Mode)
+        if test_path in self._update_permits:
+            reason = self._update_permits[test_path]
+            # Consume the permit (one-time use)
+            del self._update_permits[test_path]
+            logger.info(f"Permit consumed for {test_path}: {reason}")
+            return (True, f"Modification permitted: {reason}")
+
+        # Check if human review required
+        if config.requires_human_review(test_path):
+            if modifier == "ai":
+                return (False, f"Test requires human review: {test_path}")
+
+        # Check mutation policy
+        if config.mutation_policy == "blocked" and modifier == "ai":
+            return (False, f"AI modification blocked by policy: {test_path}")
+
+        return (True, "Modification allowed")
+
+    # ========================================================================
+    # PERMIT SYSTEM (Feature Evolution Mode)
+    # ========================================================================
+
+    def permit_update(self, test_path: str, reason: str, approved_by: str = "human") -> bool:
+        """
+        Issue a one-time permit to update a test.
+
+        This is for Feature Evolution mode when requirements change
+        and tests legitimately need updating.
+
+        The permit is consumed on first use (single-use).
+
+        Args:
+            test_path: Path to the test file
+            reason: Why the update is needed (logged to lineage)
+            approved_by: Who approved this (must be human for frozen tests)
+
+        Returns:
+            True if permit issued, False if test is frozen
+        """
+        # Frozen tests can NEVER be permitted
+        if self.is_frozen(test_path):
+            logger.error(f"Cannot permit update to FROZEN test: {test_path}")
+            return False
+
+        self._update_permits[test_path] = reason
+
+        # Record to lineage
+        self._record_to_lineage(
+            event_type="TEST_UPDATE_PERMITTED",
+            details={
+                "test_path": test_path,
+                "reason": reason,
+                "approved_by": approved_by,
+            },
+        )
+
+        logger.info(f"Permit issued for {test_path}: {reason}")
+        return True
+
+    def revoke_permit(self, test_path: str) -> bool:
+        """Revoke a previously issued permit."""
+        if test_path in self._update_permits:
+            del self._update_permits[test_path]
+            logger.info(f"Permit revoked for {test_path}")
+            return True
+        return False
+
+    def list_permits(self) -> Dict[str, str]:
+        """List all active permits."""
+        return dict(self._update_permits)
+
+    def accept_update(self, test_path: str, reason: str = "requirements changed") -> bool:
+        """
+        Accept a test mutation and update the contract.
+
+        Call this AFTER the test has been legitimately updated
+        to register the new hash as the baseline.
+
+        Args:
+            test_path: Path to the updated test
+            reason: Why the update was needed
+
+        Returns:
+            True if accepted, False if frozen
+        """
+        if self.is_frozen(test_path):
+            logger.error(f"Cannot accept update to FROZEN test: {test_path}")
+            return False
+
+        # Get new hash
+        new_hash = self.hash_file(Path(test_path))
+        old_hash = self._contracts.get(
+            test_path,
+            TestContract(
+                test_path=test_path,
+                content_hash="",
+                created_at="",
+            ),
+        ).content_hash
+
+        # Update contract
+        self._contracts[test_path] = TestContract(
+            test_path=test_path,
+            content_hash=new_hash,
+            created_at=datetime.now().isoformat(),
+            created_by="human",
+            frozen=False,
+            notes=reason,
+        )
+        self._save_baselines()
+
+        # Record to lineage
+        self._record_to_lineage(
+            event_type="TEST_CONTRACT_UPDATED",
+            details={
+                "test_path": test_path,
+                "old_hash": old_hash,
+                "new_hash": new_hash,
+                "reason": reason,
+            },
+        )
+
+        logger.info(f"Contract updated for {test_path}: {old_hash} -> {new_hash}")
+        return True
+
+    # ========================================================================
+    # LINEAGE INTEGRATION
+    # ========================================================================
+
+    def _record_to_lineage(self, event_type: str, details: Dict[str, Any]) -> None:
+        """Record event to kernel's lineage/ledger."""
+        if not self._kernel:
+            return
+
+        # Try lineage first (newer), then ledger (legacy)
+        if hasattr(self._kernel, "lineage"):
+            try:
+                self._kernel.lineage.add_block(
+                    {
+                        "event_type": event_type,
+                        "agent_id": "TEST_GUARDIAN",
+                        "details": details,
+                        "timestamp": datetime.now().isoformat(),
+                    }
+                )
+            except Exception as e:
+                logger.debug(f"Failed to record to lineage: {e}")
+
+        elif hasattr(self._kernel, "ledger"):
+            try:
+                self._kernel.ledger.record_event(
+                    event_type=event_type,
+                    agent_id="TEST_GUARDIAN",
+                    details=details,
+                )
+            except Exception as e:
+                logger.debug(f"Failed to record to ledger: {e}")
+
+    # ========================================================================
+    # REPORTING
+    # ========================================================================
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Get summary of test contracts and mutations."""
+        return {
+            "total_contracts": len(self._contracts),
+            "frozen_tests": sum(1 for c in self._contracts.values() if c.frozen),
+            "mutations_detected": len(self._mutations),
+            "policy": self._get_config().mutation_policy,
+            "regression_mode": self._get_config().regression_mode,
+        }
+
+    def print_status(self) -> str:
+        """Print human-readable status."""
+        summary = self.get_summary()
+        lines = [
+            "=" * 60,
+            "TEST GUARDIAN STATUS",
+            "=" * 60,
+            f"Test Contracts:     {summary['total_contracts']}",
+            f"Frozen Tests:       {summary['frozen_tests']}",
+            f"Mutations Detected: {summary['mutations_detected']}",
+            "",
+            f"Mutation Policy:    {summary['policy']}",
+            f"Regression Mode:    {summary['regression_mode']}",
+            "=" * 60,
+        ]
+
+        if self._mutations:
+            lines.append("\nRECENT MUTATIONS:")
+            for m in self._mutations[-5:]:
+                lines.append(f"  - {m.test_path}: {m.action_taken}")
+
+        return "\n".join(lines)
+
+
+# ============================================================================
+# EXPORTS
+# ============================================================================
+
+__all__ = [
+    "TestGuardian",
+    "TestContract",
+    "MutationEvent",
+]


### PR DESCRIPTION
Implements test suite immutability enforcement to prevent AI agents from modifying tests to hide regressions.

PROBLEM SOLVED:
- AI writes test for feature X
- Code changes break the test
- AI "fixes" the test instead of the code
- Regression goes unnoticed!

SOLUTION:
- Tests are IMMUTABLE CONTRACTS
- Hash of each test recorded at "birth" (first run)
- AI modifications BLOCKED by default
- Permit system for Feature Evolution (one-time use)
- All mutations logged to lineage (audit trail)

Components:
- config/test_governance.yaml: Policy configuration
- TestGovernanceConfig: Phoenix section (UnifiedLoader compatible)
- TestGuardian: Enforcement engine with permit system
- TestOrchestrationPlugin: Integration with guardian

Policy Hierarchy:
1. FROZEN tests (tests/hardening/**) - NEVER modifiable
2. PERMIT (one-time) - AI can modify once with human approval
3. HUMAN - Can always modify
4. AI - Blocked by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)