### PR TITLE
fix: Add manifest.json for EnvoyPlugin (was not loading)

### DIFF
--- a/vibe_core/plugins/envoy/manifest.json
+++ b/vibe_core/plugins/envoy/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "envoy",
+  "name": "Envoy Plugin",
+  "version": "1.0.0",
+  "description": "System shell for Agent City - routes user intent to circuits and agents",
+  "entry_point": "plugin_main.py",
+  "priority": 15,
+  "dependencies": ["steward_protocol"],
+  "provides_api": true
+}


### PR DESCRIPTION
The plugin loader requires manifest.json to discover new-style plugins. EnvoyPlugin was missing it, so kernel.envoy was undefined.

Now ENVOY.md shows actual routes from the EnvoyPlugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)