### PR TITLE
fix: Rebuild template context per action in DeterministicExecutor

### DIFF
--- a/vibe_core/cartridges/system/envoy/action_handlers.py
+++ b/vibe_core/cartridges/system/envoy/action_handlers.py
@@ -575,7 +575,8 @@ class QueryGraphHandler(ActionHandler):
         try:
             result = self._execute_query(target, params, context.kernel)
             logger.info(f"    ✓ Query returned {type(result).__name__}")
-            return ActionResult.ok({"query": target, "result": result})
+            # Return the result directly so it can be used in templates without .result wrapper
+            return ActionResult.ok(result if isinstance(result, dict) else {"value": result})
         except Exception as e:
             logger.error(f"    ❌ Query failed: {e}")
             return ActionResult.fail(f"Query failed: {e}")

--- a/vibe_core/cartridges/system/envoy/deterministic_executor.py
+++ b/vibe_core/cartridges/system/envoy/deterministic_executor.py
@@ -735,10 +735,10 @@ class DeterministicExecutor:
         if not phase.actions:
             return True
 
-        # Build template context for variable resolution (GAD-5000)
-        template_context = self._build_template_context(playbook, execution, intent_vector)
-
         for action in phase.actions:
+            # CRITICAL FIX (BREAK 3): Rebuild context EVERY action to get fresh phase_results
+            # This ensures that render_output phase can see results from query_status, query_agents, query_tools
+            template_context = self._build_template_context(playbook, execution, intent_vector)
             try:
                 action_type = action.get("action_type", "EXECUTE_SCRIPT")
                 # Support both 'target' and 'agent_id' for backwards compatibility
@@ -880,6 +880,29 @@ class DeterministicExecutor:
                     else:
                         logger.warning(f"  ⚠️  Nested playbook not found: {nested_playbook_id}")
                         return False
+
+                else:
+                    # GENERIC HANDLER DISPATCH (GAD-6000: QUERY_GRAPH, RENDER_TEMPLATE, etc.)
+                    # Delegate to Action Handler Registry for all other action types
+                    if self.action_registry and self.action_registry.has(action_type):
+                        handler = self.action_registry.get(action_type)
+                        action_context = ActionContext(
+                            phase_id=phase.phase_id,
+                            playbook_id=playbook.id,
+                            execution_id=execution.execution_id,
+                            user_input=execution.user_input,
+                            phase_results=execution.phase_results,
+                            kernel=kernel,
+                            emit_event=emit_event,
+                        )
+                        result = await handler.execute(resolved_target, params, action_context)
+                        if not result.success:
+                            logger.warning(f"  ❌ {action_type} failed: {result.error}")
+                            return False
+                        phase.result = result.data
+                        logger.info(f"  ✓ {action_type} completed: {resolved_target}")
+                    else:
+                        logger.warning(f"  ⚠️ Unknown action type (no handler): {action_type}")
 
             except Exception as e:
                 logger.error(f"❌ Action failed: {action} - {e}")


### PR DESCRIPTION
BREAK 3 fix from OPUS_RUNTIME_SEPARATION analysis. Template context was built once per phase, but phase_results are updated AFTER each phase completes. This meant render_output phase couldn't see results from previous phases (query_status, query_agents, etc).

Fixes:
1. Move template_context building inside the action loop so each action gets fresh phase_results
2. Add generic handler dispatch for QUERY_GRAPH, RENDER_TEMPLATE, STORE_EPHEMERAL and other action types via ActionHandlerRegistry
3. Return QUERY_GRAPH results directly without wrapper for template access

SYSTEM_STATUS_V2 circuit now renders output correctly.

Refs: docs/architecture/OPUS/OPUS_RUNTIME_SEPARATION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)