### PR TITLE
feat(opus): Add @HARNESS verification to security docs

### DIFF
--- a/docs/architecture/OPUS/018-SENIOR-SECURITY-AUDIT.md
+++ b/docs/architecture/OPUS/018-SENIOR-SECURITY-AUDIT.md
@@ -1,9 +1,39 @@
 # OPUS-018: Senior Security Audit - Verified Findings
 
-> **Status**: 📋 RESEARCH COMPLETE
+> **Status**: ✅ ADDRESSED (see OPUS-019)
 > **Date**: 2025-12-10
 > **Author**: Antigravity (Senior Architect Mode)
 > **Trigger**: OPUS senior feedback requiring code-level verification
+> **Resolution**: P0 items fixed in OPUS-019
+
+<!-- @HARNESS
+files:
+  - path: steward/crypto.py
+    required: true
+  - path: vibe_core/ledger.py
+    required: true
+  - path: vibe_core/loaders/container_loader.py
+    required: true
+  - path: vibe_core/governance/invariants.py
+    required: true
+tests:
+  - tests/integration/test_container_integrity.py
+  - tests/unit/test_crypto_verification.py
+wiring:
+  - pattern: "NIST256p"
+    in: steward/crypto.py
+  - pattern: "_verify_signature"
+    in: vibe_core/loaders/container_loader.py
+  - pattern: "verify_chain_integrity"
+    in: vibe_core/ledger.py
+  - pattern: "InvariantChecker"
+    in: vibe_core/plugins/tools/plugin_main.py
+absent:
+  - pattern: "hmac\\.new"
+    in: vibe_core/cartridges/system/herald/tools/identity_tool.py
+  - pattern: "ssl=False"
+    in: vibe_core/gateway/api.py
+-->
 
 ---
 

--- a/docs/architecture/OPUS/019-P0-RELEASE-MILESTONE.md
+++ b/docs/architecture/OPUS/019-P0-RELEASE-MILESTONE.md
@@ -5,6 +5,32 @@
 > **Branch**: main @ 1b3eb29
 > **Author**: Antigravity
 
+<!-- @HARNESS
+files:
+  - path: vibe_core/cartridges/system/herald/tools/identity_tool.py
+    required: true
+  - path: vibe_core/plugins/tools/plugin_main.py
+    required: true
+  - path: steward/crypto.py
+    required: true
+tests:
+  - tests/unit/test_crypto_verification.py
+wiring:
+  - pattern: "from steward.crypto import"
+    in: vibe_core/cartridges/system/herald/tools/identity_tool.py
+  - pattern: "InvariantChecker"
+    in: vibe_core/plugins/tools/plugin_main.py
+  - pattern: "STEWARD_CRYPTO_AVAILABLE"
+    in: vibe_core/cartridges/system/herald/tools/identity_tool.py
+absent:
+  - pattern: "hmac\\.new"
+    in: vibe_core/cartridges/system/herald/tools/identity_tool.py
+  - pattern: "sha256.*_private_key.*hexdigest"
+    in: vibe_core/cartridges/system/herald/tools/identity_tool.py
+config:
+  - section: opus.verification
+-->
+
 ---
 
 ## Release Summary


### PR DESCRIPTION
Add machine-verifiable @HARNESS sections to:
- OPUS-019: P0 Release Milestone (wiring/absent checks for ECDSA fix)
- OPUS-018: Senior Security Audit (updated status to ADDRESSED)

These harnesses enable the OPUS-000 verification panel to automatically check that security fixes haven't regressed. Key absent patterns:
- hmac.new in identity_tool.py (must not exist)
- ssl=False in gateway/api.py (must not exist)