### PR TITLE
feat(opus): Complete Fractal Holon wiring - session, heartbeat, health

### DIFF
--- a/vibe_core/plugins/opus_assistant/.opus_state/observations.jsonl
+++ b/vibe_core/plugins/opus_assistant/.opus_state/observations.jsonl
@@ -1,0 +1,6 @@
+{"timestamp": "2025-12-13T02:11:18.068054", "severity": "WARN", "message": "Drift detected after commit {{ trigger_event.commit_sha | default('unknown') }}", "source": "auto_verify", "context_hash": null}
+{"timestamp": "2025-12-13T02:11:18.113213", "severity": "WARN", "message": "Drift detected after commit {{ trigger_event.commit_sha | default('unknown') }}", "source": "auto_verify", "context_hash": null}
+{"timestamp": "2025-12-13T02:11:18.165070", "severity": "WARN", "message": "Warning message", "source": "opus_assistant", "context_hash": null}
+{"timestamp": "2025-12-13T02:11:18.166186", "severity": "ALERT", "message": "Alert message", "source": "opus_assistant", "context_hash": null}
+{"timestamp": "2025-12-13T02:11:18.181692", "severity": "WARN", "message": "New warning observation", "source": "opus_assistant", "context_hash": null}
+{"timestamp": "2025-12-13T02:11:18.186832", "severity": "WARN", "message": "Second observation", "source": "opus_assistant", "context_hash": null}

--- a/vibe_core/plugins/opus_assistant/events/kernel_tick.py
+++ b/vibe_core/plugins/opus_assistant/events/kernel_tick.py
@@ -497,9 +497,13 @@ class KernelTickHandler:
                 self._context_service.inject(context)
                 await self._context_service.broadcast(context)
 
-                # LOG: Health status changes
+                # 🔌 WIRING: Log ALL health status changes (including initial)
                 new_health = context.health.status
-                if self._last_health_status and new_health != self._last_health_status:
+                if self._last_health_status is None:
+                    # First synthesis - log initial health state
+                    self._log_observation_info(f"Initial health state: {new_health}", "context_service")
+                elif new_health != self._last_health_status:
+                    # Health changed - log transition
                     if new_health == "CRITICAL":
                         self._log_observation_alert(
                             f"Health degraded: {self._last_health_status} → {new_health}", "context_service"
@@ -873,11 +877,25 @@ class KernelTickHandler:
     # =========================================================================
 
     async def _handle_event_fallback(self, event_type: str, event: Any) -> None:
-        """Handle events that don't have circuits (backward compat)."""
+        """
+        Handle events that don't have circuits (backward compat).
+
+        🔌 WIRING: Adds heartbeat + regular flush for system liveness.
+        """
         if "KERNEL_TICK" in event_type:
-            # Minimal tick handling
-            if self._tick_count % 10 == 0:
+            # 🔌 WIRING: Flush observations every 50 ticks (~2.5 min at 3s ticks)
+            if self._tick_count % 50 == 0:
                 self._flush_observations()
+
+            # 🔌 WIRING: Heartbeat logging every 100 ticks (~5 min)
+            # Shows system is alive and gives humans visibility
+            if self._tick_count % 100 == 0 and self._tick_count > 0:
+                self._log_observation_info(
+                    f"System heartbeat: tick #{self._tick_count}, "
+                    f"circuits: {len(self._circuits)}, "
+                    f"drift_ticks: {self._consecutive_drift_ticks}",
+                    "heartbeat",
+                )
 
     # =========================================================================
     # Observation Logging (kept from original)

--- a/vibe_core/plugins/opus_assistant/plugin_main.py
+++ b/vibe_core/plugins/opus_assistant/plugin_main.py
@@ -105,6 +105,8 @@ class OpusAssistantPlugin(KernelPlugin):
         2. Load fraktale config (defaults + opus.yaml)
         3. Subscribe to kernel tick (EventBus)
         4. Quick health check
+        5. 🔌 WIRING: Save session state (Fractal Holon - "untötbar")
+        6. 🔌 WIRING: Trigger genesis check for karma-aware boot
         """
         self._kernel = kernel
 
@@ -128,15 +130,133 @@ class OpusAssistantPlugin(KernelPlugin):
         # WITHOUT modifying core files!
         self._register_context_provider()
 
-        logger.info("🎯 OPUS Assistant online (fraktale config + kernel tick + context provider)")
+        # 🔌 WIRING: Save initial session state (Fractal Holon - "untötbar")
+        self._init_session_state()
+
+        # 🔌 WIRING: Trigger genesis check for karma-aware boot
+        self._trigger_genesis_check()
+
+        logger.info("🎯 OPUS Assistant online (fraktale config + kernel tick + context provider + session state)")
 
     def on_shutdown(self, kernel: "RealVibeKernel") -> None:
         """Cleanup on kernel shutdown."""
+        # 🔌 WIRING: Save final session state before shutdown
+        self._save_session_state()
+
         # Unsubscribe from events
         if self._tick_handler:
             self._tick_handler.unsubscribe()
 
-        logger.info("🎯 OPUS Assistant shutdown")
+        logger.info("🎯 OPUS Assistant shutdown (session state saved)")
+
+    def _init_session_state(self) -> None:
+        """
+        🔌 WIRING: Initialize and save session state on boot.
+
+        This makes the system "untötbar" - it remembers sessions.
+        Loads previous session karma to inform boot mode.
+        """
+        import uuid
+        from datetime import datetime
+
+        try:
+            from vibe_core.plugins.opus_assistant.core.state_manager import (
+                SessionState,
+                get_state_manager,
+            )
+
+            state_mgr = get_state_manager()
+
+            # Load previous karma to inform boot mode
+            last_karma = state_mgr.get_last_karma()
+
+            # Determine boot mode from last karma
+            boot_mode = "full_power"
+            if last_karma:
+                if last_karma.score < 40:
+                    boot_mode = "safe_mode"
+                elif last_karma.score < 70:
+                    boot_mode = "cautious_mode"
+
+            # Create new session
+            session = SessionState(
+                session_id=str(uuid.uuid4())[:8],
+                started_at=datetime.utcnow().isoformat(),
+                last_karma_score=last_karma.score if last_karma else 100,
+                observation_count=0,
+                boot_mode=boot_mode,
+            )
+
+            state_mgr.save_session(session)
+            logger.info(f"📍 Session {session.session_id} started (boot_mode: {boot_mode})")
+
+        except Exception as e:
+            logger.warning(f"Could not init session state: {e}")
+
+    def _save_session_state(self) -> None:
+        """
+        🔌 WIRING: Save session state on shutdown.
+
+        Updates observation count and karma before exit.
+        """
+        try:
+            from vibe_core.plugins.opus_assistant.core.state_manager import get_state_manager
+
+            state_mgr = get_state_manager()
+
+            # Load current session
+            session = state_mgr.load_session()
+            if not session:
+                return
+
+            # Update with latest karma
+            last_karma = state_mgr.get_last_karma()
+            if last_karma:
+                session.last_karma_score = last_karma.score
+
+            # Update observation count
+            observations = state_mgr.get_observations()
+            session.observation_count = len(observations)
+
+            # Save updated session
+            state_mgr.save_session(session)
+            logger.debug(f"💾 Session {session.session_id} saved (karma: {session.last_karma_score})")
+
+        except Exception as e:
+            logger.warning(f"Could not save session state: {e}")
+
+    def _trigger_genesis_check(self) -> None:
+        """
+        🔌 WIRING: Trigger genesis check circuit on boot.
+
+        This makes the system karma-aware from the first moment.
+        """
+        try:
+            if self._tick_handler:
+                import asyncio
+
+                # Get the genesis check method
+                async def run_genesis():
+                    result = await self._tick_handler._check_session_karma({"lookback_hours": 24})
+                    if result.get("is_critical"):
+                        logger.warning(f"⚠️ GENESIS: Critical karma detected ({result.get('score')}/100)")
+                    elif result.get("has_warnings"):
+                        logger.info(f"🔶 GENESIS: Cautious boot ({result.get('score')}/100)")
+                    else:
+                        logger.info(f"🟢 GENESIS: Full power boot ({result.get('score')}/100)")
+
+                # Try to run the genesis check
+                try:
+                    loop = asyncio.get_event_loop()
+                    if loop.is_running():
+                        loop.create_task(run_genesis())
+                    else:
+                        loop.run_until_complete(run_genesis())
+                except RuntimeError:
+                    asyncio.run(run_genesis())
+
+        except Exception as e:
+            logger.debug(f"Genesis check skipped: {e}")
 
     def _load_fraktale_config(self) -> None:
         """


### PR DESCRIPTION
🔌 WIRING (plugin_main.py):
- Session persistence on boot/shutdown (save_session/load_session)
- Genesis check auto-trigger for karma-aware boot
- Boot mode determined by last session karma

🔌 WIRING (kernel_tick.py):
- Observation flush every 50 ticks (~2.5 min)
- Heartbeat logging every 100 ticks (~5 min)
- Initial health state logging on first synthesis
- All health transitions now logged

The OPUS Assistant is now a true Fractal Holon:
- Owns its state (.opus_state/)
- Survives git resets ("untötbar")
- Remembers sessions and karma across boots
- Shows signs of life (heartbeat)