### PR TITLE
feat(OPUS-115): Dynamic Path-to-Varga Mapping - The Body IS the Code

### DIFF
--- a/docs/architecture/OPUS/115-DYNAMIC-VARGA-MAPPING.md
+++ b/docs/architecture/OPUS/115-DYNAMIC-VARGA-MAPPING.md
@@ -1,0 +1,247 @@
+# OPUS-115: Dynamic Path-to-Varga Mapping
+
+**Status**: IMPLEMENTED
+**Date**: 2025-12-19
+**Author**: Claude (Senior Engineer)
+**Depends on**: OPUS-114 (Akshara Kernel)
+
+## Summary
+
+"शरीरमाद्यं खलु धर्मसाधनम्" - "The body is indeed the primary instrument of dharma."
+
+OPUS-115 eliminates hardcoded trigger-to-Varga mappings by deriving Varga directly
+from the file path. The folder structure IS the body - no manual wiring needed.
+
+## The Problem
+
+OPUS-114 introduced the Akshara Kernel with Varga-based resonance, but used a
+static `TRIGGER_VARGA_MAP`:
+
+```python
+# BEFORE (OPUS-114): Manual mapping - maintenance hell!
+TRIGGER_VARGA_MAP = {
+    "trigger:file_changed:vibe_core/**": Varga.OSHTHYA,
+    "trigger:file_changed:tests/**": Varga.OSHTHYA,
+    "trigger:file_changed:docs/**": Varga.OSHTHYA,
+    # ... every new path needs manual entry
+}
+```
+
+Problems:
+1. **Maintenance Overhead**: Every new folder needs manual mapping
+2. **Loss of Precision**: All `vibe_core/**` mapped to one Varga, ignoring structure
+3. **Not VEDA-4**: Static mappings don't scale or self-organize
+
+## The Solution: The Body IS the Code
+
+```python
+# AFTER (OPUS-115): Dynamic derivation - the structure IS the mapping!
+def get_trigger_varga(trigger: str) -> Varga:
+    if trigger.startswith("trigger:file_changed:"):
+        path = trigger[len("trigger:file_changed:"):]
+        return map_path_to_varga(path)  # Derive from structure!
+```
+
+Now the Varga is **derived** from the file's location, not looked up in a table.
+
+## Path-to-Varga Mapping
+
+The folder structure encodes the layer:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Varga      │ Layer      │ Paths                                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│  KANTHYA    │ KERNEL     │ vibe_core/runtime/, vibe_core/governance/,  │
+│  (Throat)   │            │ vibe_core/protocols/, .opus_state/,         │
+│             │            │ vibe_core/store/, vibe_core/state/          │
+├─────────────────────────────────────────────────────────────────────────┤
+│  TALAVYA    │ COGNITION  │ vibe_core/llm/, vibe_core/cortex/,          │
+│  (Palate)   │            │ vibe_core/plugins/opus_assistant/manas/,    │
+│             │            │ vibe_core/knowledge/, vibe_core/agents/     │
+├─────────────────────────────────────────────────────────────────────────┤
+│  MURDHANYA  │ REPAIR     │ vibe_core/plugins/doctor/, tests/,          │
+│  (Roof)     │            │ vibe_core/specialists/, *_test.py, test_*.py│
+├─────────────────────────────────────────────────────────────────────────┤
+│  DANTYA     │ INTERFACE  │ vibe_core/gateway/, vibe_core/loaders/,     │
+│  (Teeth)    │            │ vibe_core/cartridges/, docs/, *.md          │
+├─────────────────────────────────────────────────────────────────────────┤
+│  OSHTHYA    │ OUTPUT     │ vibe_core/cli/, vibe_core/phoenix/,         │
+│  (Lips)     │            │ vibe_core/settings/, *.json, *.yaml         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## The Key Insight
+
+Same trigger type, different Vargas based on PATH:
+
+```
+trigger:file_changed:vibe_core/runtime/kernel.py → KERNEL  (ङ)
+trigger:file_changed:vibe_core/llm/client.py     → COGNITION (ञ)
+trigger:file_changed:tests/test_api.py           → REPAIR  (ण)
+trigger:file_changed:docs/README.md              → INTERFACE (न)
+trigger:file_changed:vibe_core/cli/main.py       → OUTPUT  (म)
+```
+
+Before OPUS-115, ALL of these mapped to OSHTHYA (OUTPUT).
+Now each has the Varga that matches its TRUE nature.
+
+## API
+
+### New Functions
+
+```python
+from vibe_core.plugins.opus_assistant.manas.akshara import (
+    map_path_to_varga,
+    get_path_layer,
+    get_path_element,
+    get_path_akshara,
+)
+
+# Derive Varga from path
+varga = map_path_to_varga("vibe_core/runtime/kernel.py")
+# Returns: Varga.KANTHYA
+
+# Get layer name
+layer = get_path_layer("vibe_core/cli/main.py")
+# Returns: "OUTPUT"
+
+# Get element (Bhuta)
+element = get_path_element("vibe_core/llm/client.py")
+# Returns: "Vayu" (Air - Cognition)
+
+# Get representative Akshara
+akshara = get_path_akshara("tests/test_api.py")
+# Returns: Akshara(ण/ṇa) - Murdhanya nasal
+```
+
+### Updated get_trigger_varga()
+
+```python
+def get_trigger_varga(trigger: str) -> Varga:
+    """
+    OPUS-115: For file_changed triggers, dynamically derive Varga from path.
+    The file's location determines its nature, not a static map.
+    """
+    if trigger in TRIGGER_VARGA_MAP:
+        return TRIGGER_VARGA_MAP[trigger]
+
+    # OPUS-115: Dynamic path-based Varga
+    if trigger.startswith("trigger:file_changed:"):
+        path = trigger[len("trigger:file_changed:"):]
+        path = path.replace("**", "").replace("*", "")
+        if path:
+            return map_path_to_varga(path)
+        return Varga.OSHTHYA
+
+    # ... rest of function
+```
+
+## Mapping Algorithm
+
+1. **Phase 1: Folder Prefix Match** (most specific)
+   - Check if path starts with known folder patterns
+   - Order: KANTHYA → TALAVYA → MURDHANYA → DANTYA → OSHTHYA
+
+2. **Phase 2: Glob Pattern Match** (file extensions)
+   - Check `*.md`, `*.json`, `*_test.py`, etc.
+   - Same Varga order
+
+3. **Phase 3: Default** (unknown code)
+   - Return TALAVYA (COGNITION)
+   - "Unknown code is cognitive until proven otherwise"
+
+## Real-World Impact
+
+### Before (OPUS-114)
+
+```python
+# Kernel change triggers with OUTPUT resonance (wrong!)
+trigger = "trigger:file_changed:vibe_core/runtime/kernel.py"
+varga = get_trigger_varga(trigger)  # OSHTHYA
+
+# action:run_tests is KERNEL
+# Resonance: OSHTHYA → KANTHYA = 0.2 (distant)
+```
+
+### After (OPUS-115)
+
+```python
+# Kernel change triggers with KERNEL resonance (correct!)
+trigger = "trigger:file_changed:vibe_core/runtime/kernel.py"
+varga = get_trigger_varga(trigger)  # KANTHYA
+
+# action:run_tests is KERNEL
+# Resonance: KANTHYA → KANTHYA = 1.0 (perfect)
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `akshara.py` | Added `PATH_VARGA_PATTERNS`, `map_path_to_varga()`, updated `get_trigger_varga()` |
+| `akshara.py` | Removed static file_changed entries from `TRIGGER_VARGA_MAP` |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                 OPUS-115: Dynamic Path-to-Varga Flow                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  File Changed Event                                                     │
+│  └─→ "vibe_core/runtime/kernel.py"                                     │
+│                                                                         │
+│  Normalize to Trigger (OPUS-111)                                       │
+│  └─→ "trigger:file_changed:vibe_core/runtime/kernel.py"                │
+│                                                                         │
+│  get_trigger_varga() (OPUS-115)                                        │
+│  └─→ Extract path: "vibe_core/runtime/kernel.py"                       │
+│  └─→ map_path_to_varga()                                               │
+│      └─→ Phase 1: Check folder prefixes                                │
+│      └─→ Match: "vibe_core/runtime/" → KANTHYA                         │
+│  └─→ Return: Varga.KANTHYA                                             │
+│                                                                         │
+│  calculate_resonance() (OPUS-114)                                      │
+│  └─→ KANTHYA trigger → KANTHYA action = 1.0 (perfect)                  │
+│                                                                         │
+│  Dharmic Score                                                          │
+│  └─→ weight × resonance = true decision metric                         │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## The Philosophical Foundation
+
+Why derive from path structure?
+
+1. **The Body IS the Dharma** (शरीरमाद्यं खलु धर्मसाधनम्)
+   - The folder structure is the physical body of the codebase
+   - Each location has a natural function based on where it is
+
+2. **Self-Organizing Systems**
+   - No central registry to maintain
+   - Add new folders → automatic Varga assignment
+   - VEDA-4 pattern: structure encodes meaning
+
+3. **Articulatory Metaphor**
+   - Throat (KANTHYA): Where sound originates → Where code originates (kernel)
+   - Palate (TALAVYA): Where sound is shaped → Where decisions are shaped (cognition)
+   - Roof (MURDHANYA): Effort required → Fixing bugs requires effort (repair)
+   - Teeth (DANTYA): Connection point → Interfaces connect systems (interface)
+   - Lips (OSHTHYA): Output emerges → User sees output (cli/render)
+
+## Related
+
+- OPUS-111: Signal Alignment (canonical vocabulary)
+- OPUS-112: Synaptic Inference (reading brain)
+- OPUS-113: Dharmic Stress Test (validation)
+- OPUS-114: Akshara Kernel (resonance calculation)
+- OPUS-115: Dynamic Varga Mapping (this document)
+
+## Future: OPUS-116+
+
+Possible next steps:
+- **Dynamic Action Mapping**: Derive action Vargas from function signatures
+- **Chakra Integration**: 7-layer model for deployment stages
+- **Auto-Documentation**: Generate layer diagrams from path analysis

--- a/vibe_core/plugins/opus_assistant/manas/akshara.py
+++ b/vibe_core/plugins/opus_assistant/manas/akshara.py
@@ -294,11 +294,159 @@ class Varnamala:
 
 
 # =============================================================================
+# OPUS-115: DYNAMIC PATH-TO-VARGA MAPPING - The Body IS the Code
+# =============================================================================
+
+# Path patterns for each Varga layer
+# The folder structure encodes the layer - no manual mapping needed!
+PATH_VARGA_PATTERNS: Dict[Varga, List[str]] = {
+    # KANTHYA (KERNEL) - Deep Core, Foundation
+    # Throat: where sound originates, where the system originates
+    Varga.KANTHYA: [
+        "vibe_core/runtime/",  # Runtime kernel
+        "vibe_core/governance/",  # Core governance
+        "vibe_core/protocols/",  # Core protocols
+        "vibe_core/store/",  # Data store (foundation)
+        "vibe_core/state/",  # State management
+        "vibe_core/scheduling/",  # Core scheduling
+        "vibe_core/vajra/",  # Vajra (thunderbolt - core power)
+        "vibe_core/steward/",  # Steward (core manager)
+        "vibe_core/config/",  # Core configuration
+        ".opus_state/",  # OPUS kernel state
+        ".prakriti/",  # Prakriti (nature - core)
+    ],
+    # TALAVYA (COGNITION) - Decision/Flow, Intelligence
+    # Palate: where sound is shaped, where decisions are shaped
+    Varga.TALAVYA: [
+        "vibe_core/llm/",  # LLM reasoning
+        "vibe_core/cortex/",  # Cortex (brain)
+        "vibe_core/plugins/opus_assistant/manas/",  # MANAS cognition
+        "vibe_core/plugins/opus_assistant/vidya/",  # Vidya (knowledge)
+        "vibe_core/knowledge/",  # Knowledge base
+        "vibe_core/agents/",  # Agent reasoning
+        "vibe_core/playbook/",  # Playbook (decision trees)
+        "vibe_core/shadow_labs/",  # Shadow Labs (research)
+    ],
+    # MURDHANYA (REPAIR) - Hard Work, Fixing, Testing
+    # Retroflex: tongue curls back (effort), fixing requires effort
+    Varga.MURDHANYA: [
+        "vibe_core/plugins/doctor/",  # Doctor (fixing)
+        "vibe_core/plugins/test_mode/",  # Test mode
+        "vibe_core/plugins/test_orchestration/",  # Test orchestration
+        "vibe_core/specialists/",  # Specialists (experts at fixing)
+        "vibe_core/plugins/opus_assistant/narasimha/",  # Narasimha (destroyer of bugs)
+        "tests/",  # Test suite
+        "**/tests/",  # Any test folder
+        "*_test.py",  # Test files
+        "test_*.py",  # Test files
+    ],
+    # DANTYA (INTERFACE) - Links, Connections, Documentation
+    # Dental: tongue touches teeth (connection point)
+    Varga.DANTYA: [
+        "vibe_core/gateway/",  # API gateway
+        "vibe_core/loaders/",  # Data loaders
+        "vibe_core/plugins/interface/",  # Interface plugin
+        "vibe_core/plugins/envoy/",  # Envoy (connections)
+        "vibe_core/plugins/nexus_holon/",  # Nexus (connections)
+        "vibe_core/cartridges/",  # Cartridges (connectors)
+        "vibe_core/tools/",  # Tools (interfaces)
+        "docs/",  # Documentation (human interface)
+        "*.md",  # Markdown files (human interface)
+    ],
+    # OSHTHYA (OUTPUT) - Surface, User-facing, Manifestation
+    # Labial: lips produce output, user sees output
+    Varga.OSHTHYA: [
+        "vibe_core/cli/",  # CLI (user output)
+        "vibe_core/phoenix/",  # Phoenix (regeneration output)
+        "vibe_core/plugins/opus_assistant/render/",  # Rendering
+        "vibe_core/plugins/opus_assistant/cli/",  # OPUS CLI
+        "vibe_core/plugins/opus_assistant/templates/",  # Output templates
+        "vibe_core/settings/",  # User settings
+        "*.json",  # JSON output files
+        "*.yaml",  # YAML output files
+        "*.yml",  # YAML output files
+    ],
+}
+
+
+def map_path_to_varga(path: str) -> Varga:
+    """
+    OPUS-115: Dynamically derive Varga from file path.
+
+    The folder structure IS the body - each path belongs to a layer.
+    No manual mapping needed - the code's location determines its nature.
+
+    Mapping hierarchy:
+    1. Exact prefix match (most specific)
+    2. Glob pattern match
+    3. Default to TALAVYA (cognition - the middle ground)
+
+    Args:
+        path: File path (relative to workspace root)
+
+    Returns:
+        The Varga that this path belongs to
+    """
+    import fnmatch
+
+    # Normalize path (remove leading ./ prefix, not individual chars)
+    if path.startswith("./"):
+        path = path[2:]
+    if path.startswith("/"):
+        path = path[1:]
+
+    # PHASE 1: Check folder prefix patterns first (most specific)
+    for varga in [Varga.KANTHYA, Varga.TALAVYA, Varga.MURDHANYA, Varga.DANTYA, Varga.OSHTHYA]:
+        patterns = PATH_VARGA_PATTERNS.get(varga, [])
+        for pattern in patterns:
+            # Prefix match (folder paths ending with /)
+            if pattern.endswith("/"):
+                if path.startswith(pattern) or path.startswith(pattern.rstrip("/")):
+                    return varga
+
+    # PHASE 2: Check glob patterns (file extensions, etc.)
+    for varga in [Varga.KANTHYA, Varga.TALAVYA, Varga.MURDHANYA, Varga.DANTYA, Varga.OSHTHYA]:
+        patterns = PATH_VARGA_PATTERNS.get(varga, [])
+        for pattern in patterns:
+            if "*" in pattern:
+                if fnmatch.fnmatch(path, pattern):
+                    return varga
+                # Also check just the filename
+                if "/" in path:
+                    filename = path.split("/")[-1]
+                    if fnmatch.fnmatch(filename, pattern):
+                        return varga
+
+    # Default: TALAVYA (cognition) - the middle ground
+    # Unknown code is cognitive until proven otherwise
+    return Varga.TALAVYA
+
+
+def get_path_layer(path: str) -> str:
+    """Get the layer name for a path."""
+    return VARGA_LAYERS[map_path_to_varga(path)]
+
+
+def get_path_element(path: str) -> str:
+    """Get the element (Bhuta) for a path."""
+    return VARGA_ELEMENTS[map_path_to_varga(path)][1]
+
+
+def get_path_akshara(path: str) -> Akshara:
+    """Get the representative Akshara for a path."""
+    varga = map_path_to_varga(path)
+    varnamala = Varnamala.get()
+    nasal = varnamala.get_nasal(varga)
+    return nasal if nasal else varnamala.get_varga(varga)[0]
+
+
+# =============================================================================
 # TRIGGER/ACTION MAPPING - Connecting Code to Varnamala
 # =============================================================================
 
 
-# Map trigger categories to Vargas
+# Semantic trigger types mapped to Vargas (non-path-based triggers)
+# OPUS-115: file_changed triggers are now handled dynamically by map_path_to_varga()
 TRIGGER_VARGA_MAP: Dict[str, Varga] = {
     # KERNEL (Kanthya) - Core system triggers
     "trigger:test_failure": Varga.KANTHYA,
@@ -322,12 +470,7 @@ TRIGGER_VARGA_MAP: Dict[str, Varga] = {
     "trigger:sutra:missing_doc": Varga.DANTYA,
     "trigger:sutra:stale": Varga.DANTYA,
     "trigger:sutra:missing_harness": Varga.DANTYA,
-    # OUTPUT (Oshthya) - File/surface triggers
-    "trigger:file_changed:vibe_core/**": Varga.OSHTHYA,
-    "trigger:file_changed:tests/**": Varga.OSHTHYA,
-    "trigger:file_changed:docs/**": Varga.OSHTHYA,
-    "trigger:file_changed:config/**": Varga.OSHTHYA,
-    "trigger:file_changed:other": Varga.OSHTHYA,
+    # OUTPUT (Oshthya) - Misc triggers (file_changed now uses dynamic mapping!)
     "trigger:karma_low": Varga.OSHTHYA,
 }
 
@@ -357,14 +500,25 @@ ACTION_VARGA_MAP: Dict[str, Varga] = {
 
 
 def get_trigger_varga(trigger: str) -> Varga:
-    """Get the Varga for a trigger pattern."""
-    # Exact match first
+    """
+    Get the Varga for a trigger pattern.
+
+    OPUS-115: For file_changed triggers, dynamically derive Varga from path.
+    The file's location determines its nature, not a static map.
+    """
+    # Exact match first (semantic triggers)
     if trigger in TRIGGER_VARGA_MAP:
         return TRIGGER_VARGA_MAP[trigger]
 
-    # Pattern matching for file_changed triggers
+    # OPUS-115: Dynamic path-based Varga for file_changed triggers
     if trigger.startswith("trigger:file_changed:"):
-        return Varga.OSHTHYA  # OUTPUT layer
+        # Extract path from trigger: "trigger:file_changed:vibe_core/cli/main.py"
+        path = trigger[len("trigger:file_changed:") :]
+        # Remove glob patterns for mapping
+        path = path.replace("**", "").replace("*", "")
+        if path:
+            return map_path_to_varga(path)
+        return Varga.OSHTHYA  # Fallback if path is empty
 
     # Pattern matching for gap triggers
     if trigger.startswith("trigger:gap_detected:"):


### PR DESCRIPTION
"शरीरमाद्यं खलु धर्मसाधनम्" - "The body is the primary instrument of dharma."

Eliminates hardcoded trigger-to-Varga mappings by deriving Varga directly from file path structure:

New: map_path_to_varga()
- PATH_VARGA_PATTERNS: Folder patterns for each Varga layer
- Two-phase matching: folder prefixes first, then glob patterns
- Helpers: get_path_layer(), get_path_element(), get_path_akshara()

Updated: get_trigger_varga()
- file_changed triggers now use dynamic path derivation
- Removed static file_changed entries from TRIGGER_VARGA_MAP

Key insight: Same trigger type, different Vargas based on PATH:
- vibe_core/runtime/kernel.py → KERNEL (ङ)
- vibe_core/llm/client.py     → COGNITION (ञ)
- tests/test_api.py           → REPAIR (ण)
- docs/README.md              → INTERFACE (न)
- vibe_core/cli/main.py       → OUTPUT (म)

Before: ALL file_changed mapped to OSHTHYA (wrong resonance)
After: Each file has the Varga matching its TRUE nature

VEDA-4 Pattern: Structure encodes meaning, no central registry needed.