### PR TITLE
fix(hooks): Register project Stop hook in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stop.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
The project-specific stop.sh hook was present but not registered
in .claude/settings.json. This caused Claude Code to use the
global ~/.claude/stop-hook-git-check.sh instead, which doesn't
understand RuntimeStateDefinition.

Now the project Stop hook is registered, which:
- Delegates to scripts/git_gatekeeper.py
- Uses GitState.is_source_dirty()
- Leverages RuntimeStateDefinition (OPUS-081/096)
- Correctly ignores runtime state files (session.json, session.lock, etc.)

Fixes: Stop hook triggering on runtime state changes