### PR TITLE
fix(dharma): Remove ungrounded Lotus Feet claim from maha_algorithm

### DIFF
--- a/vibe_core/mahamantra/research/dharma/maha_algorithm.py
+++ b/vibe_core/mahamantra/research/dharma/maha_algorithm.py
@@ -26,10 +26,9 @@ Each step has:
     - PHASE (1-4) from quarter structure
     - OPERATION (INPUT/COMPUTE/OUTPUT) from NAME meaning
 
-LOTUS FEET FOUNDATION:
-    2 feet = HALVES
-    5 toes each = PANCHA
-    10 total = TEN = HALVES × PANCHA = FULL_SANKIRTAN_MULTIPLIER
+DERIVED CONSTANTS (from _seed.py):
+    TEN = MAHAJANA_COUNT - HALVES = 12 - 2 = 10
+    (see _seed.py RUNDE 15 for full derivation)
 
 BIT MODELS:
     512-bit:  WORDS × AKSARA = 16 × 32 = HALVES^NAVA


### PR DESCRIPTION
The "Lotus Feet Foundation" section claimed:
- 2 feet = HALVES
- 5 toes each = PANCHA
- 10 total = TEN

This had NO shastra reference and was retrofitting - HALVES comes from the two lines of the Mahamantra, not from feet. PANCHA comes from the 5 unique pairs (HK,HR,HH,KK,RR), not from toes.

Replaced with proper reference to _seed.py RUNDE 15 where TEN is actually derived: TEN = MAHAJANA_COUNT - HALVES = 12 - 2 = 10