### PR TITLE
fix(naga): TypedDict access + Protocol/Implementation alignment

### DIFF
--- a/tests/naga/test_kulika_service.py
+++ b/tests/naga/test_kulika_service.py
@@ -204,7 +204,11 @@ class TestRegistration:
         success = kulika.register_service(InstanceService, instance=instance)
 
         assert success is True
-        assert kulika.get_service_instance("instanceservice") is instance
+        # BALARAMA: Services are wrapped in NagaProxy for universal observation
+        proxy = kulika.get_service_instance("instanceservice")
+        assert proxy is not None
+        # Unwrap to verify original instance
+        assert proxy.unwrap is instance
 
     def test_register_invalid_service(self, kulika):
         """Test registering an invalid service fails."""

--- a/tests/naga/test_vasuki.py
+++ b/tests/naga/test_vasuki.py
@@ -49,9 +49,10 @@ class TestChurnOperations:
 
         envelope = vasuki.churn_out(event)
 
-        assert isinstance(envelope, SignedEnvelope)
-        assert envelope.content_type == "msgpack"
-        assert len(envelope.payload) > 0
+        # SignedEnvelope is TypedDict (dict at runtime)
+        assert isinstance(envelope, dict)
+        assert envelope["content_type"] == "msgpack"
+        assert len(envelope["payload"]) > 0
 
     def test_churn_in_restores_event(self, vasuki):
         original = {"type": "test", "nested": {"a": 1, "b": [1, 2, 3]}}
@@ -128,8 +129,9 @@ class TestNetworkSend:
 
         result = asyncio.run(vasuki.send("no_url_peer", envelope))
 
-        assert result.status == SendStatus.FAILED
-        assert "No URL configured" in result.message
+        # SendResult is TypedDict
+        assert result["status"] == SendStatus.FAILED
+        assert "No URL configured" in result["message"]
 
     def test_send_builds_correct_wire_format(self, vasuki):
         """Test that send() builds correct wire format (without actual network call)."""
@@ -137,12 +139,12 @@ class TestNetworkSend:
 
         envelope = vasuki.churn_out({"test": "data"})
 
-        # Verify envelope structure
-        assert isinstance(envelope.payload, bytes)
-        assert envelope.content_type == "msgpack"
+        # SignedEnvelope is TypedDict (dict at runtime)
+        assert isinstance(envelope["payload"], bytes)
+        assert envelope["content_type"] == "msgpack"
 
         # The wire_data structure should be base64 encoded
-        wire_payload_b64 = base64.b64encode(envelope.payload).decode()
+        wire_payload_b64 = base64.b64encode(envelope["payload"]).decode()
         assert len(wire_payload_b64) > 0
 
 
@@ -214,8 +216,9 @@ class TestReceiveQueue:
             received.append(env)
 
         assert len(received) == 2
-        assert received[0].payload == b"msg1"
-        assert received[1].payload == b"msg2"
+        # SignedEnvelope is TypedDict
+        assert received[0]["payload"] == b"msg1"
+        assert received[1]["payload"] == b"msg2"
         assert len(vasuki._receive_queue) == 0
 
 

--- a/vibe_core/naga/hiranyakashipu/wiring.py
+++ b/vibe_core/naga/hiranyakashipu/wiring.py
@@ -400,7 +400,7 @@ def wire_hiranyakashipu_to_protocols(
         if dispatcher:
             dispatcher.register_handler(
                 source=DriftSource.STRUCTURAL,
-                handler=handler,
+                handler=handler.handle,  # CorrectionHandler expects Callable
                 handler_id="hiranyakashipu_handler",
                 priority=10,  # Higher priority for security
             )

--- a/vibe_core/naga/kulika.py
+++ b/vibe_core/naga/kulika.py
@@ -567,18 +567,23 @@ class KulikaRegistry:
 
     def get_instance(self, name: str) -> Optional[Any]:
         """Get a NAGA instance by name (ADVAITA: delegates to ServiceRegistry)."""
-        # First check if we have a manifest with protocol_class
-        manifest = self._services.get(name.lower())
+        name_lower = name.lower()
+
+        # Try protocol_class first (if defined in manifest)
+        manifest = self._services.get(name_lower)
         if manifest and manifest.protocol_class:
-            try:
-                return ServiceRegistry.get(manifest.protocol_class)
-            except Exception:
-                pass
-        # Fallback: try by name directly
-        try:
-            return ServiceRegistry.get(name)
-        except Exception:
-            return None
+            result = ServiceRegistry.get(manifest.protocol_class)
+            if result is not None:
+                return result
+
+        # Try the stored class (from register() call)
+        cls = self._classes.get(name_lower)
+        if cls:
+            result = ServiceRegistry.get(cls)
+            if result is not None:
+                return result
+
+        return None
 
     def set_instance(self, name: str, instance: Any) -> None:
         """Set a NAGA instance (ADVAITA: writes to ServiceRegistry)."""
@@ -649,7 +654,7 @@ class KulikaRegistry:
         """Clear all registrations (for testing)."""
         self._services.clear()
         self._classes.clear()
-        self._instances.clear()
+        # ADVAITA: _instances removed - ServiceRegistry is single source of truth
         self._by_lord = {lord: [] for lord in NagaLord}
         self._by_domain = {domain: [] for domain in NagaDomain}
         self._by_drift_source.clear()

--- a/vibe_core/naga/services/vasuki.py
+++ b/vibe_core/naga/services/vasuki.py
@@ -302,11 +302,11 @@ class VasukiService(NagaBaseService, VasukiProtocol, TransformProtocol):
         import base64
 
         wire_data = {
-            "payload": base64.b64encode(envelope.payload).decode(),
-            "signature": base64.b64encode(envelope.signature).decode() if envelope.signature else "",
-            "sender_key": envelope.sender_key,
-            "timestamp": envelope.timestamp,
-            "content_type": envelope.content_type,
+            "payload": base64.b64encode(envelope["payload"]).decode(),
+            "signature": base64.b64encode(envelope["signature"]).decode() if envelope["signature"] else "",
+            "sender_key": envelope["sender_key"],
+            "timestamp": envelope["timestamp"],
+            "content_type": envelope["content_type"],
         }
 
         try:
@@ -321,7 +321,7 @@ class VasukiService(NagaBaseService, VasukiProtocol, TransformProtocol):
                 ) as resp:
                     if resp.status == 200:
                         self._events_processed += 1
-                        logger.debug(f"VASUKI: Sent to {target} ({len(envelope.payload)} bytes)")
+                        logger.debug(f"VASUKI: Sent to {target} ({len(envelope['payload'])} bytes)")
                         return SendResult(
                             status=SendStatus.SENT,
                             envelope_hash=envelope_hash,
@@ -387,14 +387,14 @@ class VasukiService(NagaBaseService, VasukiProtocol, TransformProtocol):
 
         self._receive_queue.append(envelope)
         self._last_heartbeat = datetime.now()
-        logger.debug(f"VASUKI: Queued incoming envelope ({len(envelope.payload)} bytes)")
+        logger.debug(f"VASUKI: Queued incoming envelope ({len(envelope['payload'])} bytes)")
         return True
 
     def _hash_envelope(self, envelope: SignedEnvelope) -> str:
         """Compute hash of envelope for tracking."""
         import hashlib
 
-        content = envelope.payload + envelope.signature
+        content = envelope["payload"] + envelope["signature"]
         return hashlib.sha256(content).hexdigest()[:16]
 
     # =========================================================================

--- a/vibe_core/protocols/naga/vasuki.py
+++ b/vibe_core/protocols/naga/vasuki.py
@@ -56,19 +56,18 @@ class SendResult(TypedDict):
     """Result of a send operation."""
 
     status: SendStatus
-    message_id: str
-    timestamp: str
-    error: Optional[str]
+    envelope_hash: str  # Hash of the sent envelope for tracking
+    message: str  # Human-readable status message
 
 
 class SignedEnvelope(TypedDict):
-    """A signed message envelope."""
+    """A signed message envelope for network transport."""
 
-    payload: str  # Serialized data
-    signature: str
-    hash: str
-    signer_id: str
-    timestamp: str
+    payload: bytes  # Serialized data (msgpack)
+    signature: bytes  # Cryptographic signature
+    sender_key: str  # Public key of sender
+    timestamp: float  # Unix timestamp
+    content_type: str  # MIME type, e.g. "msgpack"
 
 
 class IntegrityError(Exception):


### PR DESCRIPTION
BREAKING CHANGES FIXED:
- SignedEnvelope/SendResult TypedDicts now match VasukiService implementation
- All TypedDict access changed from .field to ["field"] (runtime correctness)

BUG FIXES:
- kulika.py: removed _instances.clear() (attribute deleted in ADVAITA)
- kulika.py: get_instance() now tries stored class, no unsafe except pass
- hiranyakashipu/wiring.py: handler → handler.handle for CorrectionHandler

TEST FIXES:
- test_vasuki.py: TypedDict access patterns
- test_kulika_service.py: expects NagaProxy (BALARAMA wrapping) with .unwrap

51/51 NAGA tests passing.