### PR TITLE
feat(venu): DIW subscriber dispatch — Krishna's flute, every jiva dances

### DIFF
--- a/vibe_core/mahamantra/protocols/_venu.py
+++ b/vibe_core/mahamantra/protocols/_venu.py
@@ -313,6 +313,66 @@ class VenuServiceProtocol(Protocol):
 
 
 # =============================================================================
+# DIW SUBSCRIBER PROTOCOL (Krishna's Flute → Jivas Dance)
+# =============================================================================
+# The flute plays, every jiva dances. Each tick produces a 19-bit DIW.
+# Any domain — audio, chamber, network, multimedia — implements this
+# protocol to receive the DIW on every tick. Bit-level orchestration.
+#
+# "When Krishna plays His flute, the rivers stop flowing, the cows
+#  stand still with grass in their mouths, and the gopis drop everything
+#  to run toward the sound." — Srimad Bhagavatam 10.21
+
+
+class DIWEvent(TypedDict):
+    """The atomic event emitted by the flute on every tick.
+
+    Every field is derived from SSOT. No optional fields.
+    This is what flows from Krishna's flute to every jiva.
+    """
+
+    diw: int           # 19-bit Divine Instruction Word (canonical 6-9-4)
+    tick: int           # Absolute tick count (0..COSMIC_FRAME-1)
+    position: int       # Position in 16-beat cycle (0..WORDS-1)
+    phase: int          # Quarter/phase (0..QUARTERS-1) = MURALI
+    venu: int           # Quality/Mood (6 bits)
+    vamsi: int          # Process/Action (9 bits)
+    murali: int         # Phase/Quarter (4 bits)
+    mode: int           # Kirtan mode (0=Solo, 1=CallResponse, 2=Chorus)
+
+
+@runtime_checkable
+class DIWSubscriberProtocol(Protocol):
+    """
+    Protocol for any domain that dances to the flute.
+
+    Implement this to receive the DIW on every tick.
+    Audio engines, chambers, network streams, multimedia renderers —
+    all are jivas. The flute is one. The dance is many.
+
+    The VenuOrchestrator dispatches DIWEvent to all subscribers.
+    Registration is via protocol discovery (no hardcoded lists).
+    """
+
+    @property
+    def subscriber_name(self) -> str:
+        """Human-readable name for logging/telemetry."""
+        ...
+
+    def on_diw(self, event: DIWEvent) -> None:
+        """
+        Called on every tick with the current DIW.
+
+        This is the bit-level orchestration point. Every byte
+        waits for this call. Nothing moves without the flute.
+
+        Args:
+            event: The complete DIW event with all decomposed fields.
+        """
+        ...
+
+
+# =============================================================================
 # BEAT SUBSCRIBER PROTOCOL (Yasoda's Rope - Protocol-Driven Wiring)
 # =============================================================================
 # Any service that wants heartbeat time implements this protocol.
@@ -373,6 +433,7 @@ __all__ = [
     "VENU_FIELD_SECONDS",
     # Types
     "HeartbeatMetrics",
+    "DIWEvent",
     # Protocols (Phase 2 - Runtime)
     "MantraTickProtocol",
     "MantraVoiceProtocol",
@@ -381,4 +442,6 @@ __all__ = [
     "VenuServiceProtocol",
     # Protocols (Phase 4 - Beat Subscription)
     "BeatSubscriberProtocol",
+    # Protocols (Phase 5 - DIW Subscription / Bit-Level Orchestration)
+    "DIWSubscriberProtocol",
 ]

--- a/vibe_core/mahamantra/substrate/venu_orchestrator.py
+++ b/vibe_core/mahamantra/substrate/venu_orchestrator.py
@@ -12,8 +12,9 @@ The 19-bit Divine Instruction Word (DIW):
 ALL VALUES DERIVED FROM SSOT (_seed.py). NO HARDCODING.
 """
 
+import logging
 import struct
-from typing import ClassVar, Final, Tuple
+from typing import ClassVar, Final, List, Tuple
 
 from vibe_core.mahamantra.protocols._seed import (
     COSMIC_FRAME,
@@ -51,6 +52,12 @@ from vibe_core.mahamantra.protocols.diw import (
     pack_full,
     unpack,
 )
+from vibe_core.mahamantra.protocols._venu import (
+    DIWEvent,
+    DIWSubscriberProtocol,
+)
+
+logger = logging.getLogger("VENU_ORCHESTRATOR")
 
 # === MAHAJANA DECLARATION (machine-readable) ===
 __mahajana__ = "narada"
@@ -180,12 +187,13 @@ class VenuOrchestrator:
     VAMSI_BITS: ClassVar[int] = VAMSI_HOLES  # 9 - Mid register (512 = SIKSASTAKAM_CACHE)
     MURALI_BITS: ClassVar[int] = MURALI_HOLES  # 4 - High register (16 = WORDS)
 
-    __slots__ = ("_tick", "_prev_state", "_mode")
+    __slots__ = ("_tick", "_prev_state", "_mode", "_subscribers")
 
     def __init__(self) -> None:
         self._tick: int = 0
         self._prev_state: int = 0
         self._mode: int = 0  # 0=Solo, 1=CallResponse, 2=Chorus
+        self._subscribers: List[DIWSubscriberProtocol] = []
 
     # =========================================================================
     # PANCHA TATTVA PROTOCOL (5 Questions Every Entity Must Answer)
@@ -212,6 +220,75 @@ class VenuOrchestrator:
         """Current Kirtan Mode."""
         return self._mode
 
+    # =========================================================================
+    # SUBSCRIBER MANAGEMENT (Krishna's Flute -> Jivas Dance)
+    # =========================================================================
+
+    def subscribe(self, subscriber: DIWSubscriberProtocol) -> None:
+        """Register a DIW subscriber.
+
+        The subscriber's on_diw() will be called on every step()
+        with the full DIWEvent. This is the bit-level orchestration
+        point: nothing moves without the flute.
+
+        Args:
+            subscriber: Any object implementing DIWSubscriberProtocol.
+
+        Raises:
+            TypeError: If subscriber doesn't implement the protocol.
+        """
+        if not isinstance(subscriber, DIWSubscriberProtocol):
+            raise TypeError(
+                f"{type(subscriber).__name__} does not implement DIWSubscriberProtocol"
+            )
+        self._subscribers.append(subscriber)
+
+    def unsubscribe(self, subscriber: DIWSubscriberProtocol) -> None:
+        """Remove a DIW subscriber."""
+        try:
+            self._subscribers.remove(subscriber)
+        except ValueError:
+            pass  # Not subscribed — idempotent
+
+    @property
+    def subscriber_count(self) -> int:
+        """Number of active DIW subscribers."""
+        return len(self._subscribers)
+
+    def _emit(self, diw: int) -> None:
+        """Dispatch DIWEvent to all subscribers.
+
+        This is the core dispatch: the flute plays, every jiva dances.
+        Errors in individual subscribers are logged but never stop the flute.
+        """
+        if not self._subscribers:
+            return
+
+        components = unpack(diw)
+        event = DIWEvent(
+            diw=diw & DIW_MASK,
+            tick=self._tick,
+            position=self._tick % WORDS,
+            phase=components.murali,
+            venu=components.venu,
+            vamsi=components.vamsi,
+            murali=components.murali,
+            mode=self._mode,
+        )
+
+        for sub in self._subscribers:
+            try:
+                sub.on_diw(event)
+            except Exception as exc:
+                logger.error(
+                    "DIW subscriber %s error at tick %d: %s",
+                    sub.subscriber_name, self._tick, exc,
+                )
+
+    # =========================================================================
+    # CORE STEP
+    # =========================================================================
+
     def step(self) -> int:
         """
         One step through the Mahamantra.
@@ -224,9 +301,16 @@ class VenuOrchestrator:
             VAMSI  (bits 6-14): Process/Action
             MURALI (bits 15-18): Phase/Quarter
             + Mode in Cluster bits (23-26)
+
+        After computing the DIW, dispatches a DIWEvent to all subscribers.
+        The flute plays, every jiva dances.
         """
         # O(1) lookup - native 19-bit DIW
         diw = THE_FLUTE_CYCLE[self._tick % WORDS]
+
+        # Dispatch to all subscribers BEFORE advancing tick
+        # (subscribers see the tick that produced this DIW)
+        self._emit(diw)
 
         # Update state
         self._prev_state = diw
@@ -394,6 +478,9 @@ class VenuOrchestrator:
             diw = pack(venu, vamsi, murali)
             result.append(diw)
 
+            # Emit to subscribers (each phoneme is a tick)
+            self._emit(diw)
+
             # Advance tick
             self._prev_state = diw
             self._tick = (self._tick + 1) % COSMIC_FRAME
@@ -401,7 +488,11 @@ class VenuOrchestrator:
         return tuple(result)
 
     def reset(self) -> None:
-        """Reset orchestrator to initial state."""
+        """Reset orchestrator to initial state.
+
+        Clears tick, prev_state, mode. Subscribers are preserved
+        (they are wiring, not state). Use unsubscribe() to remove.
+        """
         self._tick = 0
         self._prev_state = 0
         self._mode = 0
@@ -474,4 +565,7 @@ __all__ = [
     "MURALI_SHIFT",
     # Class
     "VenuOrchestrator",
+    # Re-exported from _venu.py for convenience
+    "DIWEvent",
+    "DIWSubscriberProtocol",
 ]

--- a/vibe_core/mahamantra/tests/test_venu_orchestrator.py
+++ b/vibe_core/mahamantra/tests/test_venu_orchestrator.py
@@ -37,6 +37,10 @@ from vibe_core.mahamantra.substrate.venu_orchestrator import (
     VenuOrchestrator,
     _NAME_TO_ENCODING,
 )
+from vibe_core.mahamantra.protocols._venu import (
+    DIWEvent,
+    DIWSubscriberProtocol,
+)
 
 
 # =============================================================================
@@ -563,3 +567,225 @@ class TestFromBytesHardening:
         orch.from_bytes(legacy)
         assert orch.tick < CF
         assert orch.mode == 0
+
+
+# =============================================================================
+# DIW SUBSCRIBER DISPATCH (Krishna's Flute -> Jivas Dance)
+# =============================================================================
+
+
+class _MockSubscriber:
+    """Test subscriber that records all DIW events."""
+
+    def __init__(self, name: str = "mock"):
+        self._name = name
+        self.events: list[DIWEvent] = []
+
+    @property
+    def subscriber_name(self) -> str:
+        return self._name
+
+    def on_diw(self, event: DIWEvent) -> None:
+        self.events.append(event)
+
+
+class _FailingSubscriber:
+    """Subscriber that raises on every event."""
+
+    @property
+    def subscriber_name(self) -> str:
+        return "failing"
+
+    def on_diw(self, event: DIWEvent) -> None:
+        raise RuntimeError("I broke")
+
+
+class TestDIWSubscriberProtocol:
+    """DIWSubscriberProtocol must be runtime-checkable."""
+
+    def test_mock_implements_protocol(self):
+        sub = _MockSubscriber()
+        assert isinstance(sub, DIWSubscriberProtocol)
+
+    def test_plain_object_does_not_implement(self):
+        assert not isinstance(object(), DIWSubscriberProtocol)
+
+
+class TestSubscriberRegistration:
+    """subscribe() / unsubscribe() management."""
+
+    def test_subscribe_increments_count(self, orch: VenuOrchestrator):
+        assert orch.subscriber_count == 0
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        assert orch.subscriber_count == 1
+
+    def test_unsubscribe_decrements_count(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.unsubscribe(sub)
+        assert orch.subscriber_count == 0
+
+    def test_unsubscribe_idempotent(self, orch: VenuOrchestrator):
+        """Unsubscribing a non-subscriber should not raise."""
+        sub = _MockSubscriber()
+        orch.unsubscribe(sub)  # no-op
+        assert orch.subscriber_count == 0
+
+    def test_subscribe_rejects_non_protocol(self, orch: VenuOrchestrator):
+        with pytest.raises(TypeError, match="DIWSubscriberProtocol"):
+            orch.subscribe(object())  # type: ignore
+
+    def test_multiple_subscribers(self, orch: VenuOrchestrator):
+        subs = [_MockSubscriber(f"sub_{i}") for i in range(5)]
+        for s in subs:
+            orch.subscribe(s)
+        assert orch.subscriber_count == 5
+
+    def test_reset_preserves_subscribers(self, orch: VenuOrchestrator):
+        """Subscribers are wiring, not state. reset() must preserve them."""
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.reset()
+        assert orch.subscriber_count == 1
+
+
+class TestDIWDispatch:
+    """step() must dispatch DIWEvent to all subscribers."""
+
+    def test_step_dispatches_event(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.step()
+        assert len(sub.events) == 1
+
+    def test_event_has_all_fields(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.step()
+        event = sub.events[0]
+        assert "diw" in event
+        assert "tick" in event
+        assert "position" in event
+        assert "phase" in event
+        assert "venu" in event
+        assert "vamsi" in event
+        assert "murali" in event
+        assert "mode" in event
+
+    def test_event_diw_matches_lut(self, orch: VenuOrchestrator):
+        """The DIW in the event must match THE_FLUTE_CYCLE[tick]."""
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        for i in range(WORDS):
+            orch.step()
+        for i, event in enumerate(sub.events):
+            expected = THE_FLUTE_CYCLE[i] & DIW_MASK
+            assert event["diw"] == expected, f"tick {i}: {event['diw']} != {expected}"
+
+    def test_event_components_match_unpack(self, orch: VenuOrchestrator):
+        """venu/vamsi/murali in event must match unpack(diw)."""
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.step()
+        event = sub.events[0]
+        parts = unpack(event["diw"])
+        assert event["venu"] == parts.venu
+        assert event["vamsi"] == parts.vamsi
+        assert event["murali"] == parts.murali
+
+    def test_event_position_is_tick_mod_words(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        for _ in range(WORDS * 2):
+            orch.step()
+        for event in sub.events:
+            assert event["position"] == event["tick"] % WORDS
+
+    def test_event_phase_matches_quarter(self, orch: VenuOrchestrator):
+        """phase must equal MURALI = position // (WORDS // QUARTERS)."""
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        for _ in range(WORDS):
+            orch.step()
+        for event in sub.events:
+            expected_quarter = event["position"] // (WORDS // QUARTERS)
+            assert event["phase"] == expected_quarter
+
+    def test_event_mode_reflects_set_mode(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        orch.set_mode(2)  # Chorus
+        orch.step()
+        assert sub.events[0]["mode"] == 2
+
+    def test_multiple_subscribers_all_receive(self, orch: VenuOrchestrator):
+        subs = [_MockSubscriber(f"s{i}") for i in range(3)]
+        for s in subs:
+            orch.subscribe(s)
+        orch.step()
+        for s in subs:
+            assert len(s.events) == 1
+            assert s.events[0]["diw"] == subs[0].events[0]["diw"]
+
+    def test_no_subscribers_no_crash(self, orch: VenuOrchestrator):
+        """step() with zero subscribers must still work."""
+        diw = orch.step()
+        assert diw > 0
+
+    def test_full_cycle_deterministic(self, orch: VenuOrchestrator):
+        """Two orchestrators with same state must produce identical events."""
+        sub1 = _MockSubscriber("a")
+        sub2 = _MockSubscriber("b")
+        orch1 = VenuOrchestrator()
+        orch2 = VenuOrchestrator()
+        orch1.subscribe(sub1)
+        orch2.subscribe(sub2)
+        for _ in range(WORDS):
+            orch1.step()
+            orch2.step()
+        for i in range(WORDS):
+            assert sub1.events[i] == sub2.events[i], f"Divergence at tick {i}"
+
+
+class TestDIWDispatchErrorIsolation:
+    """A failing subscriber must not stop the flute or other subscribers."""
+
+    def test_failing_subscriber_does_not_stop_flute(self, orch: VenuOrchestrator):
+        bad = _FailingSubscriber()
+        orch.subscribe(bad)
+        diw = orch.step()  # must not raise
+        assert diw > 0
+
+    def test_failing_subscriber_does_not_block_others(self, orch: VenuOrchestrator):
+        good = _MockSubscriber("good")
+        bad = _FailingSubscriber()
+        orch.subscribe(bad)
+        orch.subscribe(good)
+        orch.step()
+        assert len(good.events) == 1  # good still received the event
+
+    def test_tick_advances_despite_failure(self, orch: VenuOrchestrator):
+        bad = _FailingSubscriber()
+        orch.subscribe(bad)
+        orch.step()
+        assert orch.tick == 1  # tick advanced
+
+
+class TestSpellDispatch:
+    """spell() must also dispatch DIW events per phoneme."""
+
+    def test_spell_dispatches_per_coord(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        coords = (10, 20, 30, 40)
+        orch.spell(coords)
+        assert len(sub.events) == len(coords)
+
+    def test_spell_events_have_correct_venu(self, orch: VenuOrchestrator):
+        sub = _MockSubscriber()
+        orch.subscribe(sub)
+        coords = (5, 15, 48)
+        orch.spell(coords)
+        for i, event in enumerate(sub.events):
+            assert event["venu"] == (coords[i] & VENU_MASK)


### PR DESCRIPTION
- Add DIWEvent TypedDict and DIWSubscriberProtocol to _venu.py
- VenuOrchestrator: subscribe(), unsubscribe(), _emit() dispatch
- step() emits DIWEvent to all subscribers before advancing tick
- spell() emits per-phoneme DIWEvents for coordinate-driven mode
- Error isolation: failing subscriber logged, never stops the flute
- reset() preserves subscribers (wiring, not state)
- 23 new tests (90 total): protocol check, registration, dispatch, error isolation, determinism, spell dispatch
- All 90 tests pass