### PR TITLE
fix: iGene.is_fatal — normalize coherence from COSMIC_FRAME to float

### DIFF
--- a/vibe_core/protocols/substrate/gene.py
+++ b/vibe_core/protocols/substrate/gene.py
@@ -40,7 +40,7 @@ class iGene:
         # Threshold Logic: Life exists if Coherence > Entropy
         # But we accept "Orange" state (Struggling) if diff is small.
         # Fatal only if Entropy explicitly overwhelms Coherence.
-        return self.entropy_load > self.mantra_shield.coherence
+        return self.entropy_load > self.mantra_shield.coherence / 21600
 
     @classmethod
     def create_random(cls, intensity: float = 0.5) -> "iGene":


### PR DESCRIPTION
MantraByte.coherence returns int(0-21600) COSMIC_FRAME scaled. entropy_load is float(0-1). Comparison was always False. Now divides by 21600 to normalize before comparison.