### PR TITLE
refactor(r1b): switch core callers to canonical mahamantra_research i…

### DIFF
--- a/vibe_core/cli/kirtan_cli.py
+++ b/vibe_core/cli/kirtan_cli.py
@@ -124,7 +124,7 @@ class KirtanCLI:
     def _ensure_research(self):
         """Lazy-load ResearchChat."""
         if self._research_chat is None:
-            from vibe_core.mahamantra.research.research_chat import get_research_chat
+            from vibe_core.mahamantra_research.research_chat import get_research_chat
 
             self._research_chat = get_research_chat()
         return self._research_chat
@@ -318,7 +318,7 @@ class KirtanCLI:
         """
         if not args:
             # Enter interactive research mode
-            from vibe_core.mahamantra.research.research_chat import main as research_main
+            from vibe_core.mahamantra_research.research_chat import main as research_main
 
             research_main()
             return 0

--- a/vibe_core/mahamantra/audit/gaps.py
+++ b/vibe_core/mahamantra/audit/gaps.py
@@ -29,7 +29,7 @@ def get(root: Path = None) -> List[Any]:
     Returns:
         List of Gap objects with file_path, gap_type, description, severity
     """
-    from vibe_core.mahamantra.research.project_introspection import scan_codebase, find_gaps
+    from vibe_core.mahamantra_research.project_introspection import scan_codebase, find_gaps
     files, _ = scan_codebase(root or Path.cwd())
     return find_gaps(files)
 

--- a/vibe_core/mahamantra/audit/protocol_resurrection.py
+++ b/vibe_core/mahamantra/audit/protocol_resurrection.py
@@ -137,7 +137,7 @@ class Auditor:
         from vibe_core.mahamantra.protocols.seed._axioms import (
             WORDS, TRINITY, HARE_COUNT, KRISHNA_COUNT, RAMA_COUNT, PANCHA, HALVES
         )
-        from vibe_core.mahamantra.research.acintya_mathematics import QUALITIES
+        from vibe_core.mahamantra_research.acintya_mathematics import QUALITIES
 
         graph = DerivationGraph()
 

--- a/vibe_core/mahamantra/audit/scale.py
+++ b/vibe_core/mahamantra/audit/scale.py
@@ -28,7 +28,7 @@ def get(root: Path = None) -> Dict[str, Any]:
     Returns:
         Dict with: total_files, total_lines, coverage_percent, broken_lineage
     """
-    from vibe_core.mahamantra.research.project_introspection import measure_scale
+    from vibe_core.mahamantra_research.project_introspection import measure_scale
     return measure_scale(root or Path.cwd())
 
 

--- a/vibe_core/mahamantra/protocols/_gita_lens.py
+++ b/vibe_core/mahamantra/protocols/_gita_lens.py
@@ -80,7 +80,7 @@ from vibe_core.mahamantra.protocols._maha_compute import (
     get_gita_chapter,  # Attractor → Chapter
     get_gita_insight,  # Chapter → Insight
 )
-from vibe_core.mahamantra.research.gita import (
+from vibe_core.mahamantra_research.gita import (
     # Data
     CHAPTER_18_VERSE,  # The ultimate verse
     # Constants


### PR DESCRIPTION
…mports

- cli/kirtan_cli: research_chat -> vibe_core.mahamantra_research
- audit/gaps + audit/scale: project_introspection -> mahamantra_research
- audit/protocol_resurrection: acintya_mathematics -> mahamantra_research
- protocols/_gita_lens: gita imports -> mahamantra_research

Legacy compatibility path vibe_core.mahamantra.research remains via shim.