### PR TITLE
refactor(r1c): stabilize internal imports in mahamantra_research

### DIFF
--- a/vibe_core/mahamantra_research/__init__.py
+++ b/vibe_core/mahamantra_research/__init__.py
@@ -20,9 +20,9 @@ IMPORT PATTERNS:
 ================
 
 1. SPECIFIC MODULE (recommended):
-    from vibe_core.mahamantra.research.lotus_tree import LotusRadix
-    from vibe_core.mahamantra.research.physics import PHYSICS_PREDICTIONS
-    from vibe_core.mahamantra.research.dharma.maha_algorithm import MahaModularSynth
+    from vibe_core.mahamantra_research.lotus_tree import LotusRadix
+    from vibe_core.mahamantra_research.physics import PHYSICS_PREDICTIONS
+    from vibe_core.mahamantra_research.dharma.maha_algorithm import MahaModularSynth
 
 2. CATEGORY (for exploration):
     from vibe_core.mahamantra.research import lotus      # Data structures
@@ -77,7 +77,7 @@ def __getattr__(name: str):
     if name == "lotus":
         import types
 
-        from vibe_core.mahamantra.research import lotus_acintya, lotus_full_spectrum, lotus_radix_n, lotus_tree
+        from vibe_core.mahamantra_research import lotus_acintya, lotus_full_spectrum, lotus_radix_n, lotus_tree
 
         module = types.SimpleNamespace(
             LotusRadix=lotus_tree.LotusRadix,
@@ -96,7 +96,7 @@ def __getattr__(name: str):
     if name == "predictions":
         import types
 
-        from vibe_core.mahamantra.research import biology, chemistry, medicine, physics
+        from vibe_core.mahamantra_research import biology, chemistry, medicine, physics
 
         module = types.SimpleNamespace(
             PHYSICS_PREDICTIONS=physics.PHYSICS_PREDICTIONS,
@@ -110,7 +110,7 @@ def __getattr__(name: str):
     if name == "compute":
         import types
 
-        from vibe_core.mahamantra.research import computation, maha_compression, maha_generator, unified_compute
+        from vibe_core.mahamantra_research import computation, maha_compression, maha_generator, unified_compute
 
         module = types.SimpleNamespace(
             MahaGenerator=maha_generator.MahaGenerator,
@@ -120,7 +120,7 @@ def __getattr__(name: str):
 
     # DHARMA - Access to dharma submodule
     if name == "dharma":
-        from vibe_core.mahamantra.research import dharma as _dharma
+        from vibe_core.mahamantra_research import dharma as _dharma
 
         return _dharma
 
@@ -136,12 +136,12 @@ def __getattr__(name: str):
     # 1. Check for subpackage (folder with __init__.py)
     subpkg_path = research_root / name
     if subpkg_path.is_dir() and (subpkg_path / "__init__.py").exists():
-        return importlib.import_module(f"vibe_core.mahamantra.research.{name}")
+        return importlib.import_module(f"vibe_core.mahamantra_research.{name}")
 
     # 2. Check for module (.py file)
     module_path = research_root / f"{name}.py"
     if module_path.exists():
-        return importlib.import_module(f"vibe_core.mahamantra.research.{name}")
+        return importlib.import_module(f"vibe_core.mahamantra_research.{name}")
 
     raise AttributeError(f"module 'research' has no attribute '{name}'")
 
@@ -152,24 +152,24 @@ def __getattr__(name: str):
 
 # Lotus Data Structures
 # DNA k-mer (research - benchmarked, not yet promoted)
-from vibe_core.mahamantra.research.dna_kmer import Lotus8merIndex, LotusKmerRadix
+from vibe_core.mahamantra_research.dna_kmer import Lotus8merIndex, LotusKmerRadix
 
 # IP Routing (DEPRECATED - use adapters/network.py LotusIPRouter)
-from vibe_core.mahamantra.research.ip_routing import LotusIPv4Router
+from vibe_core.mahamantra_research.ip_routing import LotusIPv4Router
 
 # Lotus Tree (LotusRadix DEPRECATED - use adapters/routing.py HolographicRouter)
 # LotusArrayInt is unique research (array.array for C-speed integers)
-from vibe_core.mahamantra.research.lotus_tree import (
+from vibe_core.mahamantra_research.lotus_tree import (
     LotusArray,
     LotusArrayInt,
     LotusRadix,
 )
 
 # Generator
-from vibe_core.mahamantra.research.maha_generator import MahaGenerator
+from vibe_core.mahamantra_research.maha_generator import MahaGenerator
 
 # Predictions (most requested)
-from vibe_core.mahamantra.research.physics import PHYSICS_PREDICTIONS
+from vibe_core.mahamantra_research.physics import PHYSICS_PREDICTIONS
 
 # Research Gateway
 from vibe_core.mahamantra.research_gateway import (

--- a/vibe_core/mahamantra_research/attractor_semantics.py
+++ b/vibe_core/mahamantra_research/attractor_semantics.py
@@ -299,7 +299,7 @@ def print_cycle_analysis() -> None:
 
 def analyze_mod_space(mod: int) -> None:
     """Analyze attractors in a given mod space with semantic interpretation."""
-    from vibe_core.mahamantra.research.attractor_analysis import find_all_attractors
+    from vibe_core.mahamantra_research.attractor_analysis import find_all_attractors
     
     print(f"\n{'=' * 60}")
     print(f"MOD {mod} SEMANTIC ANALYSIS")

--- a/vibe_core/mahamantra_research/biology.py
+++ b/vibe_core/mahamantra_research/biology.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Final
 
 # Import THE LAW
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     HALVES,
     HARE_COUNT,
     JIVA_QUALITIES,

--- a/vibe_core/mahamantra_research/chemistry.py
+++ b/vibe_core/mahamantra_research/chemistry.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Final
 
 # Import THE LAW
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     GITA_CHAPTERS,
     HALVES,
     HARE_COUNT,

--- a/vibe_core/mahamantra_research/clean_room_extraction.py
+++ b/vibe_core/mahamantra_research/clean_room_extraction.py
@@ -62,7 +62,7 @@ from vibe_core.mahamantra.protocols._seed import (
     MAHA_QUANTUM,
     WORDS,
 )
-from vibe_core.mahamantra.research.dharma import MahaResonator
+from vibe_core.mahamantra_research.dharma import MahaResonator
 
 # Global resonator instance (reuse, don't recreate)
 _RESONATOR = MahaResonator(mod_space=MAHA_QUANTUM)

--- a/vibe_core/mahamantra_research/computation.py
+++ b/vibe_core/mahamantra_research/computation.py
@@ -24,7 +24,7 @@ __genesis__ = "0xad41d0c4"  # GenesisByte: parampara % 37 == 0
 
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     HALVES,
     HARE_COUNT,
     LILA,

--- a/vibe_core/mahamantra_research/dna_kmer.py
+++ b/vibe_core/mahamantra_research/dna_kmer.py
@@ -36,7 +36,7 @@ __genesis__ = "0xbe5ddc45"  # GenesisByte: parampara % 37 == 0
 import array
 from typing import Final
 
-from ..protocols._seed import QUARTERS, WORDS
+from vibe_core.mahamantra.protocols._seed import QUARTERS, WORDS
 
 # =============================================================================
 # CONSTANTS

--- a/vibe_core/mahamantra_research/gap_analysis.py
+++ b/vibe_core/mahamantra_research/gap_analysis.py
@@ -53,7 +53,7 @@ from vibe_core.mahamantra.protocols._seed import (
 )
 
 # Use project introspection
-from vibe_core.mahamantra.research.project_introspection import (
+from vibe_core.mahamantra_research.project_introspection import (
     FileInfo,
     extract_imports,
     scan_codebase,
@@ -228,7 +228,7 @@ def analyze_research_production_gap(files: List[FileInfo]) -> Tuple[List[GapReco
                     source_file=rf.path,
                     description=f"Core research module '{module_name}' not imported by any production code",
                     severity="warning",
-                    recommendation=f"Import from vibe_core.mahamantra.research.{module_name}",
+                    recommendation=f"Import from vibe_core.mahamantra_research.{module_name}",
                 )
             )
         elif len(importers) == 0:

--- a/vibe_core/mahamantra_research/git/__init__.py
+++ b/vibe_core/mahamantra_research/git/__init__.py
@@ -6,7 +6,7 @@ Echte Git-Analyse mit Production mahamantra imports.
 Kein Buzzword-Marketing. Nur Daten.
 
 USAGE:
-    from vibe_core.mahamantra.research.git import GitLab
+    from vibe_core.mahamantra_research.git import GitLab
     lab = GitLab()
     lab.analyze(months=6)
 """

--- a/vibe_core/mahamantra_research/gita/__init__.py
+++ b/vibe_core/mahamantra_research/gita/__init__.py
@@ -30,7 +30,7 @@ FILES:
 
 USAGE:
 ======
-    from vibe_core.mahamantra.research.gita import (
+    from vibe_core.mahamantra_research.gita import (
         GITA_CHAPTERS,      # 18 (The Fixed Point)
         GITA_VERSES,        # 700 (Total verses)
         CHAPTER_18_VERSE,   # BG 18.66 data
@@ -41,7 +41,7 @@ USAGE:
     assert verify_fixed_point() == True
 
     # Access specific verse data
-    from vibe_core.mahamantra.research.gita import get_verse
+    from vibe_core.mahamantra_research.gita import get_verse
     verse = get_verse(18, 66)  # The ultimate instruction
 """
 

--- a/vibe_core/mahamantra_research/gita_verse_content.py
+++ b/vibe_core/mahamantra_research/gita_verse_content.py
@@ -73,7 +73,7 @@ from vibe_core.mahamantra.protocols._seed import (
     TRINITY,
     WORDS,
 )
-from vibe_core.mahamantra.research.gita_verse_derivation import (
+from vibe_core.mahamantra_research.gita_verse_derivation import (
     KEY_VERSES,
     DerivedVerse,
 )

--- a/vibe_core/mahamantra_research/gita_verse_text.py
+++ b/vibe_core/mahamantra_research/gita_verse_text.py
@@ -78,7 +78,7 @@ from vibe_core.mahamantra.protocols._seed import (
 )
 
 # Das ECHTE Encoding-System
-from vibe_core.mahamantra.research.shabda_translation import (
+from vibe_core.mahamantra_research.shabda_translation import (
     SANSKRIT_PHONEME_MAP,
     SPARSHA_CONSONANTS,
     VARNAMALA_TOTAL,

--- a/vibe_core/mahamantra_research/golden_age_peak.py
+++ b/vibe_core/mahamantra_research/golden_age_peak.py
@@ -108,7 +108,7 @@ import math
 from dataclasses import dataclass
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     GITA_CHAPTERS,
     JIVA_CYCLE,
     KSETRAJNA,

--- a/vibe_core/mahamantra_research/guardian_lexikon_bridge.py
+++ b/vibe_core/mahamantra_research/guardian_lexikon_bridge.py
@@ -49,13 +49,13 @@ from vibe_core.mahamantra.protocols._seed import (
     TRINITY,
     WORDS,
 )
-from vibe_core.mahamantra.research.guardian_syllable_trees import (
+from vibe_core.mahamantra_research.guardian_syllable_trees import (
     ALL_GUARDIANS,
     KNOWN_CONSTANTS,
     compute_guardian_syllable_vibrations,
 )
-from vibe_core.mahamantra.research.shabda_spawning import compute_vibration_sum
-from vibe_core.mahamantra.research.syllable_analysis import (
+from vibe_core.mahamantra_research.shabda_spawning import compute_vibration_sum
+from vibe_core.mahamantra_research.syllable_analysis import (
     syllabify_sanskrit,
     syllable_to_rama_index,
 )

--- a/vibe_core/mahamantra_research/guardian_syllable_trees.py
+++ b/vibe_core/mahamantra_research/guardian_syllable_trees.py
@@ -50,13 +50,13 @@ from vibe_core.mahamantra.protocols._seed import (
     TRINITY,
     WORDS,
 )
-from vibe_core.mahamantra.research.shabda_spawning import (
+from vibe_core.mahamantra_research.shabda_spawning import (
     ShabdaSeed,
     ShabdaTree,
     compute_vibration_sum,
     create_mahamantra_forest,
 )
-from vibe_core.mahamantra.research.syllable_analysis import (
+from vibe_core.mahamantra_research.syllable_analysis import (
     RAMA_GRID,
     syllabify_sanskrit,
     syllable_to_rama_index,

--- a/vibe_core/mahamantra_research/gut_synthesis.py
+++ b/vibe_core/mahamantra_research/gut_synthesis.py
@@ -369,7 +369,7 @@ def prove_unification() -> GUTProof:
 
     # 5. Get coverage from introspection
     try:
-        from vibe_core.mahamantra.research.project_introspection import measure_scale
+        from vibe_core.mahamantra_research.project_introspection import measure_scale
 
         metrics = measure_scale()
         parampara_cov = metrics.get("valid_parampara", 0) / max(metrics.get("total_files", 1), 1)
@@ -377,7 +377,7 @@ def prove_unification() -> GUTProof:
         parampara_cov = 0.0
 
     try:
-        from vibe_core.mahamantra.research.gap_analysis import run_full_analysis
+        from vibe_core.mahamantra_research.gap_analysis import run_full_analysis
 
         report = run_full_analysis()
         seed_cov = report.seed_coverage

--- a/vibe_core/mahamantra_research/ip_routing.py
+++ b/vibe_core/mahamantra_research/ip_routing.py
@@ -42,7 +42,7 @@ __genesis__ = "0x006e3e0a"  # GenesisByte: parampara % 37 == 0
 import warnings
 from typing import Final, Optional
 
-from ..protocols._seed import QUARTERS, WORDS
+from vibe_core.mahamantra.protocols._seed import QUARTERS, WORDS
 
 # =============================================================================
 # CONSTANTS (kept for backward compatibility and benchmarking)

--- a/vibe_core/mahamantra_research/japa.py
+++ b/vibe_core/mahamantra_research/japa.py
@@ -32,7 +32,7 @@ __genesis__ = "0x76f4fec6"  # GenesisByte: parampara % 37 == 0
 
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     CHAITANYA_BIRTH,  # 1486 = Chaitanya's appearance year
     CHAITANYA_UNION,
     HALVES,

--- a/vibe_core/mahamantra_research/lotus/__init__.py
+++ b/vibe_core/mahamantra_research/lotus/__init__.py
@@ -27,7 +27,7 @@ STRUCTURE:
 
 USAGE:
 ======
-    from vibe_core.mahamantra.research.lotus import LotusRadixN
+    from vibe_core.mahamantra_research.lotus import LotusRadixN
 
     # 16-bit keys (65,536 key space)
     index = LotusRadixN[str](levels=4)
@@ -66,17 +66,18 @@ __genesis__ = "0x6013ddeb"  # GenesisByte: parampara % 37 == 0
 # =============================================================================
 
 # From lotus_tree.py - Optimized 16-bit implementations
-from vibe_core.mahamantra.research.lotus_tree import (
+from vibe_core.mahamantra_research.lotus_tree import (
     LotusArrayInt,
     LotusRadixInt,
     KEY_SPACE,
     LEVELS,
+    RADIX,
     SLOTS_PER_LEVEL,
     BITS_PER_LEVEL,
 )
 
 # From lotus_radix_n.py - Generic N-level implementation
-from vibe_core.mahamantra.research.lotus_radix_n import (
+from vibe_core.mahamantra_research.lotus_radix_n import (
     LotusRadixN,
     lotus_16bit,
     lotus_32bit,

--- a/vibe_core/mahamantra_research/lotus_radix_n.py
+++ b/vibe_core/mahamantra_research/lotus_radix_n.py
@@ -73,7 +73,7 @@ __genesis__ = "0xbd0f4898"  # GenesisByte: parampara % 37 == 0
 
 from typing import Any, Final, Generic, Iterator, TypeVar
 
-from ..protocols._seed import WORDS
+from vibe_core.mahamantra.protocols._seed import WORDS
 
 # =============================================================================
 # CONSTANTS

--- a/vibe_core/mahamantra_research/lotus_tree.py
+++ b/vibe_core/mahamantra_research/lotus_tree.py
@@ -31,7 +31,7 @@ __genesis__ = "0xcb60fa27"  # GenesisByte: parampara % 37 == 0
 import array
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     HALF_SIZE,
     KSETRAJNA,
     MAHAJANA_COUNT,

--- a/vibe_core/mahamantra_research/maha_compose_prototype.py
+++ b/vibe_core/mahamantra_research/maha_compose_prototype.py
@@ -35,7 +35,7 @@ from vibe_core.mahamantra.protocols._seed import (
 )
 
 # Section routing from verified analysis
-from vibe_core.mahamantra.research.language_model_resonance import (
+from vibe_core.mahamantra_research.language_model_resonance import (
     CHAPTER_18_SECTIONS,
     SECTION_SIGNATURES,
 )

--- a/vibe_core/mahamantra_research/maha_generator.py
+++ b/vibe_core/mahamantra_research/maha_generator.py
@@ -22,7 +22,7 @@ import math
 from typing import Final
 
 # Import THE LAW (7 axioms + primary derivations)
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     COSMIC_FRAME,
     FIELD_RESONANCE,
     GITA_CHAPTERS,

--- a/vibe_core/mahamantra_research/maha_language_engine.py
+++ b/vibe_core/mahamantra_research/maha_language_engine.py
@@ -518,10 +518,10 @@ class MahaLanguageEngine:
             5. Section → Verse Template
         """
         from vibe_core.mahamantra.adapters.synth import create_synth
-        from vibe_core.mahamantra.research.language_model_resonance import (
+        from vibe_core.mahamantra_research.language_model_resonance import (
             SECTION_SIGNATURES,
         )
-        from vibe_core.mahamantra.research.maha_compose_prototype import (
+        from vibe_core.mahamantra_research.maha_compose_prototype import (
             extract_template,
             route_to_section,
         )
@@ -578,7 +578,7 @@ class MahaLanguageEngine:
         and RESONATE (prana adds). This creates a unique standing wave
         for every distinct prompt.
         """
-        from vibe_core.mahamantra.research.language_runtime.antaranga_bridge import (
+        from vibe_core.mahamantra_research.language_runtime.antaranga_bridge import (
             impact_keystroke,
             modulate_with_diw,
         )
@@ -727,7 +727,7 @@ class MahaLanguageEngine:
         )
 
         # Layer 3: Shabda spawning — H/K/R derivative seeds from attractor
-        from vibe_core.mahamantra.research.shabda_spawning import ShabdaSeed
+        from vibe_core.mahamantra_research.shabda_spawning import ShabdaSeed
 
         root = ShabdaSeed(
             text=guardian_name,
@@ -911,7 +911,7 @@ class MahaLanguageEngine:
         Position = (attractor mod WORDS) + 1 because MahaSequencer expects 1-16.
         Length = QUARTERS (4) — one phoneme per phase.
         """
-        from vibe_core.mahamantra.research.maha_sequencer import MahaSequencer
+        from vibe_core.mahamantra_research.maha_sequencer import MahaSequencer
 
         seq = MahaSequencer()
         position = (attractor % WORDS) + KSETRAJNA  # 1-16

--- a/vibe_core/mahamantra_research/mahajana_derivation.py
+++ b/vibe_core/mahamantra_research/mahajana_derivation.py
@@ -60,7 +60,7 @@ from vibe_core.mahamantra.protocols._seed import (
     WORDS,
 )
 
-from vibe_core.mahamantra.research.shabda_translation import (
+from vibe_core.mahamantra_research.shabda_translation import (
     VibrationSignature,
     ArticulationPoint,
     VoicingType,

--- a/vibe_core/mahamantra_research/medicine.py
+++ b/vibe_core/mahamantra_research/medicine.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Final
 
 # Import THE LAW
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     COSMIC_FRAME,
     FIELD_RESONANCE,
     GITA_CHAPTERS,

--- a/vibe_core/mahamantra_research/moores_law.py
+++ b/vibe_core/mahamantra_research/moores_law.py
@@ -24,7 +24,7 @@ __genesis__ = "0x072a8f12"  # GenesisByte: parampara % 37 == 0
 
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     HALVES,
     LILA,
     MAHAJANA_COUNT,

--- a/vibe_core/mahamantra_research/physics.py
+++ b/vibe_core/mahamantra_research/physics.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     # Building blocks
     AKSARA_COUNT,
     FIELD_RESONANCE,

--- a/vibe_core/mahamantra_research/research_chat.py
+++ b/vibe_core/mahamantra_research/research_chat.py
@@ -118,7 +118,7 @@ class ResearchResponse:
 
 def _handle_scale_query(query: ResearchQuery) -> ResearchResponse:
     """Handle query about codebase scale."""
-    from vibe_core.mahamantra.research.project_introspection import measure_scale
+    from vibe_core.mahamantra_research.project_introspection import measure_scale
 
     try:
         metrics = measure_scale()
@@ -154,7 +154,7 @@ DERIVED FROM:
 
 def _handle_gaps_query(query: ResearchQuery) -> ResearchResponse:
     """Handle query about gaps in the system."""
-    from vibe_core.mahamantra.research.gap_analysis import run_full_analysis
+    from vibe_core.mahamantra_research.gap_analysis import run_full_analysis
 
     try:
         report = run_full_analysis()
@@ -193,7 +193,7 @@ TOP GAPS:
 
 def _handle_module_query(query: ResearchQuery) -> ResearchResponse:
     """Handle query about a specific module."""
-    from vibe_core.mahamantra.research.project_introspection import (
+    from vibe_core.mahamantra_research.project_introspection import (
         extract_mahajana_info,
         scan_codebase,
     )
@@ -414,7 +414,7 @@ Coherence:  {validation["coherence"]}
 """
 
     if validation["prabhupada_year"]:
-        from vibe_core.mahamantra.research.dharma.maha_algorithm import PRABHUPADA_BUILD
+        from vibe_core.mahamantra_research.dharma.maha_algorithm import PRABHUPADA_BUILD
 
         delta = validation["prabhupada_year"] - PRABHUPADA_BUILD
         content += f"""PRABHUPADA RESONANCE:
@@ -459,7 +459,7 @@ def _handle_kirtan_query(query: ResearchQuery) -> ResearchResponse:
 
     Bridges LilaStepSequencer (7-beat) with MahaAlgorithm for max computing.
     """
-    from vibe_core.mahamantra.research.dharma.maha_algorithm import (
+    from vibe_core.mahamantra_research.dharma.maha_algorithm import (
         SEVEN,
         MahaKirtan,
     )

--- a/vibe_core/mahamantra_research/research_lab.py
+++ b/vibe_core/mahamantra_research/research_lab.py
@@ -60,7 +60,7 @@ from vibe_core.mahamantra.protocols._seed import (
 # Use ACTUAL Lotus data structures!
 # NOTE: LotusArrayInt is unique research (array.array for C-speed)
 # For radix tree, use HolographicRouter from adapters/routing.py
-from vibe_core.mahamantra.research.lotus_tree import (
+from vibe_core.mahamantra_research.lotus_tree import (
     KEY_SPACE,
     LotusArrayInt,
 )

--- a/vibe_core/mahamantra_research/resonance_response.py
+++ b/vibe_core/mahamantra_research/resonance_response.py
@@ -504,7 +504,7 @@ def respond(intent: str) -> ResonanceResponse:
 
     This is the main entry point for simple usage:
 
-        from vibe_core.mahamantra.research.resonance_response import respond
+        from vibe_core.mahamantra_research.resonance_response import respond
 
         response = respond("What is the meaning of life?")
         print(response.syllables.as_string)  # e.g., "a-kha-dha-u"

--- a/vibe_core/mahamantra_research/self_organization.py
+++ b/vibe_core/mahamantra_research/self_organization.py
@@ -35,7 +35,7 @@ EXPERIMENT:
 import ast
 from typing import Dict, List, Tuple
 
-from vibe_core.mahamantra.research.lotus_file_addressing import (
+from vibe_core.mahamantra_research.lotus_file_addressing import (
     CodeFragment,
     parse_file_to_fragments,
 )

--- a/vibe_core/mahamantra_research/shabda_translation.py
+++ b/vibe_core/mahamantra_research/shabda_translation.py
@@ -54,7 +54,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     ABHINNA_MATERIAL,
     ABHINNA_SPIRITUAL,
     AKSARA_COUNT,

--- a/vibe_core/mahamantra_research/test_immune_system.py
+++ b/vibe_core/mahamantra_research/test_immune_system.py
@@ -234,7 +234,7 @@ def scan_lotus() -> ImmuneReport:
 
     # 5. Axiom verification (spiritual_tdd.py)
     try:
-        from vibe_core.mahamantra.research.spiritual_tdd import (
+        from vibe_core.mahamantra_research.spiritual_tdd import (
             run_spiritual_tests, verify_all_derived,
         )
         axiom_results = run_spiritual_tests()

--- a/vibe_core/mahamantra_research/tulasi_lila.py
+++ b/vibe_core/mahamantra_research/tulasi_lila.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Tuple
 import datetime
 
 # Import research dependencies
-from vibe_core.mahamantra.research.bhoga_prasadam import transform, KSETRAJNA, PRASADAM
+from vibe_core.mahamantra_research.bhoga_prasadam import transform, KSETRAJNA, PRASADAM
 from vibe_core.mahamantra.protocols._seed import (
     HARE_COUNT, 
     KRISHNA_COUNT,

--- a/vibe_core/mahamantra_research/unified_compute.py
+++ b/vibe_core/mahamantra_research/unified_compute.py
@@ -47,7 +47,7 @@ __genesis__ = "0x4f97da85"  # GenesisByte: parampara % 37 == 0
 from dataclasses import dataclass
 from typing import Final
 
-from ..protocols._seed import (
+from vibe_core.mahamantra.protocols._seed import (
     GITA_CHAPTERS,
     KSETRAJNA,
     KSHETRA,

--- a/vibe_core/mahamantra_research/verify_chapter18_sections.py
+++ b/vibe_core/mahamantra_research/verify_chapter18_sections.py
@@ -36,7 +36,7 @@ assert int(__genesis__, 16) % PARAMPARA == 0, "BROKEN LINEAGE"
 
 # --- Imports ---
 from vibe_core.mahamantra.protocols._seed import PANCHA, TRINITY
-from vibe_core.mahamantra.research.language_model_resonance import (
+from vibe_core.mahamantra_research.language_model_resonance import (
     CHAPTER_18_SECTIONS,
     CHAPTER_18_VERSES,
 )


### PR DESCRIPTION
Complete canonical import migration within mahamantra_research package:
- Switch all internal cross-references from legacy vibe_core.mahamantra.research.* to canonical vibe_core.mahamantra_research.*
- Fix 14 relative imports (from ..protocols._seed) to absolute imports
- Update docstrings and lazy-load paths in __init__.py
- Migrate 37 files total

Legacy compatibility shim at vibe_core/mahamantra/research/__init__.py remains functional.

Tested:
- Canonical imports: vibe_core.mahamantra_research.* ✓
- Legacy imports: vibe_core.mahamantra.research.* ✓ (via shim)