### PR TITLE
Phase 6 Substrate Reduction: route external imports through public API

### DIFF
--- a/vibe_core/boot_orchestrator.py
+++ b/vibe_core/boot_orchestrator.py
@@ -64,13 +64,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from vibe_core.boot_mode import BootMode
 from vibe_core.config import CityConfig
 from vibe_core.event_bus import EventBus
-from vibe_core.protocols.event import EventBusProtocol
-
-# OPUS-095: Removed RealVibeKernel dependency (Dependency Inversion)
-from vibe_core.protocols.kernel_protocol import KernelProtocol
-from vibe_core.protocols.boot_protocol import BootProtocol, KernelFactoryProtocol
-from vibe_core.protocols.substrate.byte import GenesisByte
-from vibe_core.services.kernel_factory import KernelFactory
 from vibe_core.operator_adapter import (
     LocalLLMOperator,
     TerminalOperator,
@@ -78,6 +71,11 @@ from vibe_core.operator_adapter import (
 )
 from vibe_core.orchestration_cycle import CognitiveCycle, CycleContext
 from vibe_core.plugins.opus_assistant.manas.intent_generator import Intent
+from vibe_core.protocols.boot_protocol import BootProtocol, KernelFactoryProtocol
+from vibe_core.protocols.event import EventBusProtocol
+
+# OPUS-095: Removed RealVibeKernel dependency (Dependency Inversion)
+from vibe_core.protocols.kernel_protocol import KernelProtocol
 from vibe_core.protocols.operator_protocol import (
     GitState,
     IntentType,
@@ -85,9 +83,11 @@ from vibe_core.protocols.operator_protocol import (
     OperatorType,
     SystemContext,
 )
+from vibe_core.protocols.substrate.byte import GenesisByte
 from vibe_core.runtime.boot_sequence import BootSequence
 from vibe_core.runtime.unified_trace import UnifiedTrace
 from vibe_core.sarga import get_sarga
+from vibe_core.services.kernel_factory import KernelFactory
 
 logger = logging.getLogger("BOOT_ORCHESTRATOR")
 
@@ -176,7 +176,8 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         if not trace:
             trace = UnifiedTrace()
         if not event_bus:
-            from vibe_core.mahamantra.substrate.event_bus import get_event_bus
+            from vibe_core.mahamantra import get_event_bus
+
             event_bus = get_event_bus()
         self.setup(trace, event_bus, steward_context=None)
 
@@ -289,6 +290,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         detects this via _bootstrapped flag and skips redundant bootstrap.
         """
         from vibe_core.mahamantra import mahamantra as _lotus
+
         if not _lotus._bootstrapped:
             _lotus.bootstrap(silent=True)
             logger.info("      → Mahamantra bootstrapped (primary boot)")
@@ -300,6 +302,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         logger.info("⚡ OPUS-095: Materializing Kernel via Factory (AKASHA)")
         raw_kernel = self._kernel_factory.get_kernel(ledger_path=self.ledger_path)
         from vibe_core.runtime.entropy_shell import EntropyShell
+
         self.kernel = EntropyShell(raw_kernel)
         logger.info(f"      → Kernel space allocated & wrapped in EntropyShell (ledger: {self.ledger_path})")
 
@@ -307,6 +310,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         """ORIENT Step 2: VAYU (Air) — Establish communication channels."""
         logger.info("⚡ OPUS-095: Establishing communication (VAYU)")
         from vibe_core.runtime.prompt_context import PromptContext
+
         self.prompt_context = PromptContext()
         if self.kernel:
             self.prompt_context.set_kernel(self.kernel)
@@ -325,6 +329,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         from vibe_core.protocols.kernel_protocol import KernelFactoryProtocol
         from vibe_core.services.kernel_factory import KernelFactory
+
         ServiceRegistry.register(KernelFactoryProtocol, KernelFactory())
         logger.info("      → KernelFactoryProtocol registered (EphemeralCities)")
 
@@ -348,10 +353,10 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
     def _orient_agni_services(self) -> None:
         """ORIENT Step 3c: AGNI — Cartridge, Plugin, Circuit, Section services."""
-        from vibe_core.di import ServiceRegistry
-
         from vibe_core.cartridge_service import CartridgeService
+        from vibe_core.di import ServiceRegistry
         from vibe_core.protocols.cartridge import CartridgeProtocol
+
         cartridge_svc = CartridgeService.get_instance(self.project_root)
         cartridge_svc.scan()
         ServiceRegistry.register(CartridgeProtocol, cartridge_svc)
@@ -359,6 +364,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         from vibe_core.plugin_service import PluginService
         from vibe_core.protocols.plugin import PluginServiceProtocol
+
         plugin_svc = PluginService.get_instance(self.project_root)
         plugin_svc.scan()
         ServiceRegistry.register(PluginServiceProtocol, plugin_svc)
@@ -366,6 +372,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         from vibe_core.circuit_service import CircuitService
         from vibe_core.protocols.circuit import CircuitServiceProtocol
+
         circuit_svc = CircuitService.get_instance(self.project_root)
         circuit_svc.scan()
         ServiceRegistry.register(CircuitServiceProtocol, circuit_svc)
@@ -373,6 +380,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         from vibe_core.protocols.section import SectionServiceProtocol
         from vibe_core.section_service import SectionService
+
         section_svc = SectionService.get_instance(self.project_root)
         section_svc.scan()
         ServiceRegistry.register(SectionServiceProtocol, section_svc)
@@ -514,6 +522,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         if not self.boot_mode.should_skip_daily_ritual():
             from vibe_core.steward.daily_ritual import DailyRitual
+
             self.kernel.daily_ritual = DailyRitual(self.kernel)
             logger.info("      → Daily Ritual attached (time dimension active)")
         else:
@@ -539,6 +548,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_discover_beat_subscribers(self) -> None:
         """ACT Step 3: YASODA'S ROPE — Auto-discover BeatSubscribers."""
         from vibe_core.services.beat_discovery import discover_and_register_beat_subscribers
+
         discover_and_register_beat_subscribers()
         beat_count = self._venu_service.discover_beat_subscribers()
         if beat_count:
@@ -547,6 +557,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_discover_diw_subscribers(self) -> None:
         """ACT Step 4: VENU FLUTE — Auto-discover DIW subscribers."""
         from vibe_core.services.diw_discovery import discover_and_register_diw_subscribers
+
         discover_and_register_diw_subscribers()
         diw_count = self._venu_service.discover_subscribers()
         if diw_count:
@@ -555,11 +566,14 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_register_mala_flush(self) -> None:
         """ACT Step 5: MALA FLUSH — Every 108 ticks (~27s), flush RAM state to disk."""
         from vibe_core.state.state_service import get_state_service
+
         _state_svc = get_state_service(self.project_root)
+
         def _mala_flush(mala_count: int) -> None:
             flushed = _state_svc.flush()
             if flushed:
                 logger.debug(f"Mala {mala_count}: flushed {flushed} state files")
+
         self._venu_service.clock.on_mala(_mala_flush)
         logger.info("      → Mala flush registered (RAM→Disk every 108 ticks)")
 
@@ -568,6 +582,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         # Balarama wrapping now happens inside lotus.bootstrap() via auto_wrap_services().
         # We just read the result here for logging.
         from vibe_core.mahamantra import mahamantra as _lotus
+
         proxies = getattr(_lotus, "_balarama_proxies", None)
         if proxies:
             logger.info(f"      → Balarama: {len(proxies)} services already absorbed (via lotus.bootstrap)")
@@ -579,6 +594,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
         # wire_gate_providers() is idempotent, but lotus.bootstrap() already calls it.
         # We just verify they're armed.
         from vibe_core.mahamantra.substrate.tattva_registry import get_registry
+
         count = get_registry().gate_provider_count()
         if count:
             logger.info(f"      → {count} gate providers active (wired via lotus.bootstrap)")
@@ -586,11 +602,13 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_arm_io_sentinel(self) -> None:
         """ACT Step 8: I/O Sentinel — already armed by gate_providers import (verify only)."""
         from vibe_core.mahamantra.substrate.io_sentinel import is_armed
+
         if is_armed():
             logger.info("      → I/O Sentinel armed (via gate_providers import)")
         else:
             # Fallback: arm explicitly if not yet armed
             from vibe_core.mahamantra.substrate.io_sentinel import arm
+
             arm()
             logger.info("      → I/O Sentinel armed (explicit fallback)")
 
@@ -600,6 +618,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
             parse_file_to_fragments,
             register_fragments_as_cells,
         )
+
         mahamantra_root = Path(__file__).parent / "mahamantra"
         ingested_cells = 0
         ingested_files = 0
@@ -623,7 +642,8 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_wire_sravanam(self) -> None:
         """ACT Step 10: Sravanam — already wired by lotus.bootstrap() (verify only)."""
         from vibe_core.mahamantra.dharma.kumaras import sravanam as _srav_mod
-        listener = getattr(_srav_mod, '_listener', None)
+
+        listener = getattr(_srav_mod, "_listener", None)
         if listener:
             logger.info("      → Sravanam listener active (wired via lotus.bootstrap)")
         else:
@@ -632,6 +652,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
     def _act_register_governance_hook(self) -> None:
         """ACT Step 11: Governance hook — already registered by lotus.bootstrap() (verify only)."""
         from vibe_core.protocols.substrate.mantra_protocol import has_governance_hook
+
         if has_governance_hook():
             logger.info("      → Sudarshana governance hook active (via lotus.bootstrap)")
         else:
@@ -858,6 +879,7 @@ class BootOrchestrator(CognitiveCycle, BootProtocol):
 
         # EVERYTHING ELSE → lotus.execute() (the single routing point)
         from vibe_core.mahamantra import mahamantra as _lotus
+
         try:
             result = _lotus.execute(intent.raw_input or "")
             if result.get("success"):

--- a/vibe_core/cli/gates.py
+++ b/vibe_core/cli/gates.py
@@ -44,18 +44,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Final, List, Optional, Tuple, Union
 
+from vibe_core.protocols.substrate.mantra.acintya import PARAMPARA
+
 # =============================================================================
 # MANTRA SUBSTRATE IMPORTS (The Source)
 # =============================================================================
-
 from vibe_core.protocols.substrate.mantra.lotus import (
-    grow_lotus,
-    LotusQuarter,
     LOTUS_POSITIONS,
+    LotusQuarter,
+    grow_lotus,
 )
-
-from vibe_core.protocols.substrate.mantra.acintya import PARAMPARA
-
 
 # =============================================================================
 # GATE CONSTANTS (From Mantra)
@@ -239,7 +237,7 @@ def execute_gate(
     try:
         import importlib
 
-        from vibe_core.mahamantra.substrate.seed import ALL_GUARDIANS
+        from vibe_core.mahamantra import ALL_GUARDIANS
 
         # Get guardian name from position and load module
         guardian_name = ALL_GUARDIANS[position]

--- a/vibe_core/cli/naga_commands/serve/chat.py
+++ b/vibe_core/cli/naga_commands/serve/chat.py
@@ -178,8 +178,7 @@ class ChatCommand(NagaCommandBase):
 
     def _get_help(self) -> str:
         """Help text - shows the INTENT_MAP truth, not local lies."""
-        from vibe_core.mahamantra.substrate.intents import INTENT_MAP
-        from vibe_core.mahamantra.substrate.seed import ALL_GUARDIANS
+        from vibe_core.mahamantra import ALL_GUARDIANS, INTENT_MAP
 
         lines = ["[PRAHLADA] Available intents (from INTENT_MAP SSOT):\n"]
 

--- a/vibe_core/gateway/mahamantra_gateway.py
+++ b/vibe_core/gateway/mahamantra_gateway.py
@@ -73,8 +73,8 @@ class GovardhanGateway(GatewayProtocol):
         This is the ONE entry point. CLI, HTTP, CHAT, AGENT — all come here.
         The gates fire at the boundary, then the pure core computes.
         """
+        from vibe_core.mahamantra import TattvaGate
         from vibe_core.mahamantra.substrate.lotus_core import get_mahamantra
-        from vibe_core.mahamantra.substrate.pancha_tattva import TattvaGate
 
         lotus = get_mahamantra()
         command = request["command"]
@@ -85,31 +85,40 @@ class GovardhanGateway(GatewayProtocol):
         # GATE 0: PARSE — What is this?
         # Boundary IN: validate the request shape before it enters.
         # =================================================================
-        lotus.fire_gate(TattvaGate.PARSE, {
-            "input_data": command,
-            "entry_type": entry_type,
-            "args": args,
-        })
+        lotus.fire_gate(
+            TattvaGate.PARSE,
+            {
+                "input_data": command,
+                "entry_type": entry_type,
+                "args": args,
+            },
+        )
 
         # =================================================================
         # GATE 1: VALIDATE — Is it legitimate?
         # Compress to seed, verify parampara at the border.
         # =================================================================
-        lotus.fire_gate(TattvaGate.VALIDATE, {
-            "input_text": command,
-            "seed": None,  # seed computed inside __call__
-            "input_coords": None,
-        })
+        lotus.fire_gate(
+            TattvaGate.VALIDATE,
+            {
+                "input_text": command,
+                "seed": None,  # seed computed inside __call__
+                "input_coords": None,
+            },
+        )
 
         # =================================================================
         # GATE 2: EXECUTE — Pure computation (Vrindavan).
         # __call__() is deterministic. No side-effects.
         # =================================================================
-        lotus.fire_gate(TattvaGate.EXECUTE, {
-            "seed": None,
-            "attractor": None,
-            "parampara_verified": None,
-        })
+        lotus.fire_gate(
+            TattvaGate.EXECUTE,
+            {
+                "seed": None,
+                "attractor": None,
+                "parampara_verified": None,
+            },
+        )
 
         try:
             result = lotus(command)
@@ -132,24 +141,30 @@ class GovardhanGateway(GatewayProtocol):
         # GATE 3: RESULT — Is the output valid?
         # Boundary OUT: verify the computation result.
         # =================================================================
-        lotus.fire_gate(TattvaGate.RESULT, {
-            "attractor": result.get("vibration", {}).get("attractor"),
-            "resonant_words": result.get("smaranam", ()),
-            "verse_result": result.get("verse"),
-        })
+        lotus.fire_gate(
+            TattvaGate.RESULT,
+            {
+                "attractor": result.get("vibration", {}).get("attractor"),
+                "resonant_words": result.get("smaranam", ()),
+                "verse_result": result.get("verse"),
+            },
+        )
 
         # =================================================================
         # GATE 4: SYNC — Side-effects (governance).
         # This is where I/O happens. The pure core never touches disk.
         # =================================================================
-        lotus.fire_gate(TattvaGate.SYNC, {
-            "position": result.get("position"),
-            "guardian": result.get("guardian"),
-            "seed": result.get("vibration", {}).get("seed"),
-            "attractor": result.get("vibration", {}).get("attractor"),
-            "opcode": result.get("guna", {}).get("opcode"),
-            "guna": result.get("guna", {}).get("mode"),
-        })
+        lotus.fire_gate(
+            TattvaGate.SYNC,
+            {
+                "position": result.get("position"),
+                "guardian": result.get("guardian"),
+                "seed": result.get("vibration", {}).get("seed"),
+                "attractor": result.get("vibration", {}).get("attractor"),
+                "opcode": result.get("guna", {}).get("opcode"),
+                "guna": result.get("guna", {}).get("mode"),
+            },
+        )
 
         # Reset gate state
         lotus._active_gate = None
@@ -165,7 +180,9 @@ class GovardhanGateway(GatewayProtocol):
             position=result["position"],
             guardian=result["guardian"],
             quarter=result["quarter"],
-            guna=result.get("verse", {}).get("guna", result.get("guna", {}).get("mode", "sattva")) if result.get("verse") else result.get("guna", {}).get("mode", "sattva"),
+            guna=result.get("verse", {}).get("guna", result.get("guna", {}).get("mode", "sattva"))
+            if result.get("verse")
+            else result.get("guna", {}).get("mode", "sattva"),
             entry_type=entry_type,
             routed_via="govardhan",
         )

--- a/vibe_core/mahamantra/__init__.py
+++ b/vibe_core/mahamantra/__init__.py
@@ -29,6 +29,7 @@ __genesis__ = "0x7340d7d6"
 # This makes Python's import system go through the Lotus principle:
 # FOLDER = EXISTENCE = WIRING. Files can be moved without breaking imports.
 from vibe_core.mahamantra.substrate.lotus_finder import install as _install_lotus_finder
+
 _install_lotus_finder()
 
 from vibe_core.mahamantra.substrate.wiring import enable_universal_discovery
@@ -46,30 +47,39 @@ CORE_MODULES = [
     # === SEED (The DNA) ===
     "vibe_core.mahamantra.seed.types",
     "vibe_core.mahamantra.protocols._seed_cell",
-
     # === SUBSTRATE (The Engine) ===
-    "vibe_core.mahamantra.substrate.lotus_core",    # MahamantraLotus, mahamantra, lotus
-    "vibe_core.mahamantra.substrate.lotus_types",   # LotusNode
-    "vibe_core.mahamantra.substrate.mahajana",      # Enums
-    "vibe_core.mahamantra.substrate.opcode",        # MantraOpCode
-    "vibe_core.mahamantra.substrate.protocol",      # Base Protocols
-    "vibe_core.mahamantra.substrate.errors",        # Error Codes
-    "vibe_core.mahamantra.substrate.position",      # Position Logic
-    "vibe_core.mahamantra.substrate.cell",          # MahaCellUnified
-    "vibe_core.mahamantra.substrate.config",        # PhoenixConfig
-    "vibe_core.mahamantra.substrate.boot",          # BootMode
-    "vibe_core.mahamantra.substrate.event_types",   # EventType, EventColor (zero-dep leaf)
-    "vibe_core.mahamantra.substrate.event_bus",     # EventBus
-    "vibe_core.mahamantra.substrate.ledger",        # SQLiteLedger
-    "vibe_core.mahamantra.substrate.lineage",       # LineageChain, LineageBlock, LineageEventType
-    "vibe_core.mahamantra.substrate.shuddhi",       # ShuddhiProtocol, ShuddhiStatus, ShuddhiResult
+    "vibe_core.mahamantra.substrate.lotus_core",  # MahamantraLotus, mahamantra, lotus
+    "vibe_core.mahamantra.substrate.lotus_types",  # LotusNode
+    "vibe_core.mahamantra.substrate.mahajana",  # Enums
+    "vibe_core.mahamantra.substrate.opcode",  # MantraOpCode, MAHAJANA_OPCODES
+    "vibe_core.mahamantra.substrate.protocol",  # Base Protocols
+    "vibe_core.mahamantra.substrate.errors",  # Error Codes
+    "vibe_core.mahamantra.substrate.position",  # Position Logic
+    "vibe_core.mahamantra.substrate.cell",  # MahaCellUnified
+    "vibe_core.mahamantra.substrate.config",  # PhoenixConfig
+    "vibe_core.mahamantra.substrate.boot",  # BootMode
+    "vibe_core.mahamantra.substrate.event_types",  # EventType, EventColor (zero-dep leaf)
+    "vibe_core.mahamantra.substrate.event_bus",  # EventBus, get_event_bus
+    "vibe_core.mahamantra.substrate.ledger",  # SQLiteLedger
+    "vibe_core.mahamantra.substrate.lineage",  # LineageChain, LineageBlock, LineageEventType
+    "vibe_core.mahamantra.substrate.shuddhi",  # ShuddhiProtocol, ShuddhiStatus, ShuddhiResult
     "vibe_core.mahamantra.substrate.process_manager",  # ProcessManager, AgentProcessInfo, ProcessStatus
-    "vibe_core.mahamantra.substrate.maha_state",      # MahaState, StateEntry, get_maha_state, pierce
-    
+    "vibe_core.mahamantra.substrate.maha_state",  # MahaState, StateEntry, get_maha_state, pierce
+    # === PHASE 6: Substrate Reduction — Public API surface ===
+    "vibe_core.mahamantra.substrate.byte",  # MantraByte, HolyName, GenesisByte
+    "vibe_core.mahamantra.substrate.guna",  # Guna, GunaQoS, SATTVA_OPCODES
+    "vibe_core.mahamantra.substrate.seed",  # ALL_GUARDIANS, MAHAMANTRA, HALF_SIZE
+    "vibe_core.mahamantra.substrate.tattva",  # KshetraElement, GuruTattva
+    "vibe_core.mahamantra.substrate.nadi",  # NadiProtocol, LocalNadi, NadiType
+    "vibe_core.mahamantra.substrate.intents",  # INTENT_MAP, get_position_for_intent
+    "vibe_core.mahamantra.substrate.io_sentinel",  # is_armed, arm, drain_violations
+    "vibe_core.mahamantra.substrate.pancha_tattva",  # TattvaGate
+    "vibe_core.mahamantra.substrate.wiring",  # POSITION_BY_NAME
+    "vibe_core.mahamantra.substrate.samskara",  # Samskara types
     # === PROTOCOLS (The Standard) ===
-    "vibe_core.mahamantra.protocols._gad",          # GADBase
-    "vibe_core.mahamantra.protocols._header",       # MahaHeader
-    "vibe_core.mahamantra.protocols._payload",      # PayloadType
+    "vibe_core.mahamantra.protocols._gad",  # GADBase
+    "vibe_core.mahamantra.protocols._header",  # MahaHeader
+    "vibe_core.mahamantra.protocols._payload",  # PayloadType
 ]
 
 # Enable Universal Discovery (Fractal + Core Modules)
@@ -82,13 +92,16 @@ enable_universal_discovery(globals(), __file__, CORE_MODULES)
 # Universal discovery only resolves classes/functions, not module-level variables.
 _original_getattr = globals().get("__getattr__")
 
+
 def __getattr__(name):
     if name == "lotus":
         from vibe_core.mahamantra.substrate.lotus_core import lotus
+
         return lotus
     if _original_getattr is not None:
         return _original_getattr(name)
     raise AttributeError(f"module 'vibe_core.mahamantra' has no attribute {name!r}")
+
 
 def __dir__():
     """Module-level __dir__ so lazy __getattr__ names appear in dir()."""
@@ -102,7 +115,17 @@ def __dir__():
 # =============================================================================
 
 __all__ = [
-    "MahamantraLotus", "mahamantra", "AkashState", "ExecuteResult", "PhoenixConfig",
-    "genesis", "dharma", "karma", "moksha",
-    "substrate", "protocols", "adapters", "kernel",
+    "MahamantraLotus",
+    "mahamantra",
+    "AkashState",
+    "ExecuteResult",
+    "PhoenixConfig",
+    "genesis",
+    "dharma",
+    "karma",
+    "moksha",
+    "substrate",
+    "protocols",
+    "adapters",
+    "kernel",
 ]

--- a/vibe_core/services/chat_indriya.py
+++ b/vibe_core/services/chat_indriya.py
@@ -49,6 +49,9 @@ if TYPE_CHECKING:
     from vibe_core.protocols.chat import ChatResponse
 from uuid import uuid4
 
+# Import Nadi infrastructure (for interfacing, not owning)
+from vibe_core.mahamantra import NadiProtocol, NadiType
+
 # Import Indriya infrastructure
 from vibe_core.mahamantra.protocols._indriya import (
     VRTTI_COUNT,
@@ -62,14 +65,10 @@ from vibe_core.mahamantra.protocols._indriya import (
     TanmatraMessage,
     Vrtti,
 )
-
-# Import Nadi infrastructure (for interfacing, not owning)
 from vibe_core.mahamantra.substrate.nadi import (
     NadiMessage,
     NadiOp,
     NadiPriority,
-    NadiProtocol,
-    NadiType,
 )
 
 # Import ChatService (BRAIN) - ChatIndriya wraps this (Balarama Pattern)
@@ -86,6 +85,7 @@ def _get_chat_service():
 
 # Import seed constants
 # GAD compliance
+from vibe_core.mahamantra import WORDS
 from vibe_core.mahamantra.protocols._gad import GADBase
 from vibe_core.mahamantra.protocols._seed import HARE_COUNT
 from vibe_core.mahamantra.protocols._seed import WORDS as SEED_WORDS
@@ -108,7 +108,6 @@ from vibe_core.mahamantra.substrate.seed import (
     NADI_RESONANCE,
     NAVA,
     PRANA_DURATION_MS,
-    WORDS,
 )
 
 logger = logging.getLogger("CHAT_INDRIYA")

--- a/vibe_core/services/chat_nadi.py
+++ b/vibe_core/services/chat_nadi.py
@@ -39,26 +39,23 @@ from datetime import datetime
 from typing import Any, Callable, Dict, Final, List, Optional
 from uuid import uuid4
 
+# Import Nadi infrastructure
+from vibe_core.mahamantra import WORDS, LocalNadi, NadiProtocol, NadiType
+
 # GAD compliance
 from vibe_core.mahamantra.protocols._gad import GADBase
-
-# Import Nadi infrastructure
 from vibe_core.mahamantra.substrate.nadi import (
     NADI_TIMEOUT_MS,
-    LocalNadi,
     NadiConnection,
     NadiMessage,
     NadiOp,
     NadiPriority,
-    NadiProtocol,
-    NadiType,
 )
 
 # Import seed constants
 from vibe_core.mahamantra.substrate.seed import (
     NADI_RESONANCE,
     PRANA_DURATION_MS,
-    WORDS,
 )
 
 # Import ChatSubstrateBridge for routing

--- a/vibe_core/services/chat_refinement.py
+++ b/vibe_core/services/chat_refinement.py
@@ -18,21 +18,21 @@ __position__ = 2
 __genesis__ = "0x66d82a7a"  # GenesisByte: parampara % 37 == 0
 
 import logging
+import uuid
 from datetime import datetime
 from typing import Dict, List, Optional
-import uuid
 
+from vibe_core.mahamantra.protocols._lotus import get_position_mahajana
 from vibe_core.protocols.chat import (
-    ChatMode,
-    ChatMessage,
-    ChatResponse,
     ChatContext,
+    ChatMessage,
+    ChatMode,
+    ChatResponse,
     RefinementPath,
     RefinementRequest,
     RefinementState,
 )
 from vibe_core.protocols.cognition import CognitiveResult, IntentType
-from vibe_core.mahamantra.protocols._lotus import get_position_mahajana
 
 logger = logging.getLogger("CHAT_REFINEMENT")
 
@@ -110,7 +110,7 @@ def discover_refinement_paths(
     Returns:
         List of RefinementPath candidates, sorted by confidence
     """
-    from vibe_core.mahamantra.substrate.intents import INTENT_MAP
+    from vibe_core.mahamantra import INTENT_MAP
 
     paths = []
     msg_lower = message.lower()
@@ -337,7 +337,7 @@ def simple_intent_detection(message: str) -> CognitiveResult:
     Uses mahamantra/substrate/intents.py - NO ML, pure dict lookup.
     Extracted from ChatService for modularity.
     """
-    from vibe_core.mahamantra.substrate.intents import get_position_for_intent
+    from vibe_core.mahamantra import get_position_for_intent
 
     msg_lower = message.lower()
     words = msg_lower.split()

--- a/vibe_core/services/chat_service.py
+++ b/vibe_core/services/chat_service.py
@@ -43,6 +43,8 @@ import uuid
 # NAGAs INFORM, they don't CONTROL (GAD-000 principle)
 from typing import TYPE_CHECKING
 
+# NADI - Energy channels (User ↔ System via PRANA)
+from vibe_core.mahamantra import MantraOpCode, NadiProtocol, NadiType
 from vibe_core.mahamantra.protocols._lotus import (
     MAHAJANA_POSITIONS,
     LotusBase,
@@ -65,16 +67,11 @@ from vibe_core.mahamantra.substrate.harmonics import (
 from vibe_core.mahamantra.substrate.harmonics import (
     ResonanceHarmonics,
 )
-
-# NADI - Energy channels (User ↔ System via PRANA)
 from vibe_core.mahamantra.substrate.nadi import (
     NadiMessage,
     NadiOp,
-    NadiProtocol,
-    NadiType,
     get_nadi,
 )
-from vibe_core.mahamantra.substrate.opcode import MantraOpCode
 
 # KSHETRA - The 24 Tattvas (BG 13.6-7)
 # Chat invokes: SHROTRA (hear), VAK (speak), MANAS (think), BUDDHI (understand)
@@ -535,8 +532,14 @@ class ChatService(ChatProtocol, LotusBase):
         mode = determine_chat_mode(cognitive_result, lotus_result)
         return cognitive_result, lotus_result, mode
 
-    async def _chat_execute(self, message: str, cognitive_result: "CognitiveResult",
-                            lotus_result: dict, mode: "ChatMode", context: ChatContext) -> object:
+    async def _chat_execute(
+        self,
+        message: str,
+        cognitive_result: "CognitiveResult",
+        lotus_result: dict,
+        mode: "ChatMode",
+        context: ChatContext,
+    ) -> object:
         """Chat Step 4: Execute if actionable (ShadowReactor or cli_bridge)."""
         execution_result = None
         if cognitive_result.intent_type == IntentType.EXECUTE or mode == ChatMode.SYSCALL:
@@ -550,8 +553,9 @@ class ChatService(ChatProtocol, LotusBase):
                 logger.info(f"⚡ ChatService: EXECUTED via cli_bridge → {execution_result}")
         return execution_result
 
-    def _chat_build_context(self, message: str, lotus_result: dict,
-                            execution_result: object, naga_context: object) -> dict:
+    def _chat_build_context(
+        self, message: str, lotus_result: dict, execution_result: object, naga_context: object
+    ) -> dict:
         """Chat Step 5: Build knowledge context with execution result + NAGA intelligence."""
         knowledge_context = self._get_knowledge_context_lotus(message, lotus_result)
         if execution_result:
@@ -565,26 +569,43 @@ class ChatService(ChatProtocol, LotusBase):
         self._lotus_bloom(lotus_result)
         return knowledge_context
 
-    async def _chat_respond(self, message: str, context: ChatContext,
-                            cognitive_result: "CognitiveResult", lotus_result: dict,
-                            knowledge_context: dict, mode: "ChatMode",
-                            magnitude: float, execution_result: object) -> ChatResponse:
+    async def _chat_respond(
+        self,
+        message: str,
+        context: ChatContext,
+        cognitive_result: "CognitiveResult",
+        lotus_result: dict,
+        knowledge_context: dict,
+        mode: "ChatMode",
+        magnitude: float,
+        execution_result: object,
+    ) -> ChatResponse:
         """Chat Step 6: Generate LLM response, create ChatResponse, complete lotus cycle."""
         response_text = await self._generate_response_lotus(
-            message=message, context=context, cognitive_result=cognitive_result,
-            lotus_result=lotus_result, knowledge_context=knowledge_context,
+            message=message,
+            context=context,
+            cognitive_result=cognitive_result,
+            lotus_result=lotus_result,
+            knowledge_context=knowledge_context,
         )
         response_msg = ChatMessage(
-            content=response_text, role="assistant", timestamp=datetime.now(),
-            session_id=context.session_id, message_id=str(uuid.uuid4()),
-            opcode=lotus_result.get("opcode", "EXTEND_CAP"), mahajana=lotus_result["mahajana"],
+            content=response_text,
+            role="assistant",
+            timestamp=datetime.now(),
+            session_id=context.session_id,
+            message_id=str(uuid.uuid4()),
+            opcode=lotus_result.get("opcode", "EXTEND_CAP"),
+            mahajana=lotus_result["mahajana"],
         )
         self._sessions[context.session_id].append(response_msg)
         response = ChatResponse(
-            success=True, message=response_msg, mode=mode,
+            success=True,
+            message=response_msg,
+            mode=mode,
             intent_type=cognitive_result.intent_type,
             opcode=lotus_result.get("opcode", "EXTEND_CAP"),
-            mahajana=lotus_result["mahajana"], confidence=magnitude,
+            mahajana=lotus_result["mahajana"],
+            confidence=magnitude,
         )
         self._lotus_garuda(executed=execution_result is not None)
         return response
@@ -617,23 +638,36 @@ class ChatService(ChatProtocol, LotusBase):
             execution_result = await self._chat_execute(message, cognitive_result, lotus_result, mode, context)
             knowledge_context = self._chat_build_context(message, lotus_result, execution_result, naga_context)
             response = await self._chat_respond(
-                message, context, cognitive_result, lotus_result,
-                knowledge_context, mode, magnitude, execution_result,
+                message,
+                context,
+                cognitive_result,
+                lotus_result,
+                knowledge_context,
+                mode,
+                magnitude,
+                execution_result,
             )
 
             self._report_to_narada("END", message, context, response)
             kshetra_names = [e.name for e in self._active_kshetra]
-            logger.info(f"🕉️ ChatService: Lotus cycle complete - {len(self._active_kshetra)} Tattvas active: {kshetra_names}")
+            logger.info(
+                f"🕉️ ChatService: Lotus cycle complete - {len(self._active_kshetra)} Tattvas active: {kshetra_names}"
+            )
             return response
 
         except Exception as e:
             logger.error(f"❌ ChatService: Chat failed: {e}")
             error_msg = ChatMessage(
-                content=f"Chat error: {e}", role="assistant",
-                timestamp=datetime.now(), session_id=context.session_id,
+                content=f"Chat error: {e}",
+                role="assistant",
+                timestamp=datetime.now(),
+                session_id=context.session_id,
             )
             error_response = ChatResponse(
-                success=False, message=error_msg, mode=ChatMode.DIRECT, error=str(e),
+                success=False,
+                message=error_msg,
+                mode=ChatMode.DIRECT,
+                error=str(e),
             )
             self._report_to_narada("ERROR", message, context, error_response)
             return error_response
@@ -705,7 +739,7 @@ class ChatService(ChatProtocol, LotusBase):
             }
 
         # FALLBACK: Legacy keyword matching (INTENT_MAP)
-        from vibe_core.mahamantra.substrate.intents import get_position_for_intent
+        from vibe_core.mahamantra import get_position_for_intent
 
         msg_lower = message.lower()
         words = msg_lower.split()
@@ -764,8 +798,7 @@ class ChatService(ChatProtocol, LotusBase):
 
         VarnaTensor observes phonetics for future Akasha learning.
         """
-        from vibe_core.mahamantra.substrate.intents import INTENT_MAP, get_position_for_intent
-        from vibe_core.mahamantra.substrate.seed import ALL_GUARDIANS, HALF_SIZE
+        from vibe_core.mahamantra import ALL_GUARDIANS, HALF_SIZE, INTENT_MAP, get_position_for_intent
 
         msg_lower = message.lower()
         words = msg_lower.split()
@@ -1061,7 +1094,8 @@ class ChatService(ChatProtocol, LotusBase):
             return None
 
         try:
-            from vibe_core.mahamantra.substrate.seed import HALF_SIZE
+            from vibe_core.mahamantra import HALF_SIZE
+
             position = lotus_result.get("position", 2)
 
             # Only use Shadow for PARASHURAMA (8) or BRAHMA (1) positions

--- a/vibe_core/services/chat_substrate_bridge.py
+++ b/vibe_core/services/chat_substrate_bridge.py
@@ -33,23 +33,19 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, Final, List, Optional, Tuple
 
+# Substrate imports
+from vibe_core.mahamantra import MAHAMANTRA, WORDS, HolyName, MantraByte
 from vibe_core.mahamantra.protocols._gad import GADBase
 from vibe_core.mahamantra.protocols._lotus import (
     MAHAJANA_POSITIONS,
     get_position_mahajana,
 )
-
-# Substrate imports
 from vibe_core.mahamantra.substrate.byte import (
     MANTRA_SEQUENCE,
-    HolyName,
     MantraBit,
-    MantraByte,
 )
 from vibe_core.mahamantra.substrate.seed import (
-    MAHAMANTRA,
     PARAMPARA,
-    WORDS,
     Quarter,
 )
 

--- a/vibe_core/services/narada_bridge.py
+++ b/vibe_core/services/narada_bridge.py
@@ -48,12 +48,12 @@ _QUARTER_NAMES = ("genesis", "dharma", "karma", "moksha")
 class DIWContext(TypedDict):
     """Rhythmic context stamped onto every agent event after bridge is wired."""
 
-    diw: int           # 19-bit Divine Instruction Word
-    tick: int          # Absolute tick count
-    position: int      # Position in 16-beat cycle (0..15)
-    phase: int         # Quarter/phase (0..3)
-    quarter: str       # Quarter name (genesis/dharma/karma/moksha)
-    mode: int          # Kirtan mode (0=Solo, 1=CallResponse, 2=Chorus)
+    diw: int  # 19-bit Divine Instruction Word
+    tick: int  # Absolute tick count
+    position: int  # Position in 16-beat cycle (0..15)
+    phase: int  # Quarter/phase (0..3)
+    quarter: str  # Quarter name (genesis/dharma/karma/moksha)
+    mode: int  # Kirtan mode (0=Solo, 1=CallResponse, 2=Chorus)
 
 
 class NaradaBridge:
@@ -70,8 +70,12 @@ class NaradaBridge:
     """
 
     __slots__ = (
-        "_context", "_prev_phase", "_total_ticks",
-        "_phase_transitions", "_event_bus_ref", "_event_bus_failed",
+        "_context",
+        "_prev_phase",
+        "_total_ticks",
+        "_phase_transitions",
+        "_event_bus_ref",
+        "_event_bus_failed",
     )
 
     def __init__(self) -> None:
@@ -193,7 +197,7 @@ class NaradaBridge:
         from_quarter = _QUARTER_NAMES[from_phase % QUARTERS]
         to_quarter = _QUARTER_NAMES[to_phase % QUARTERS]
 
-        from vibe_core.mahamantra.substrate.event_bus import EventType
+        from vibe_core.mahamantra import EventType
 
         bus.emit_sync(
             event_type=EventType.PHASE_TRANSITION,
@@ -207,7 +211,9 @@ class NaradaBridge:
 
         logger.debug(
             "Phase transition: %s → %s at tick %d",
-            from_quarter, to_quarter, tick,
+            from_quarter,
+            to_quarter,
+            tick,
         )
 
     def _get_event_bus(self):
@@ -221,7 +227,8 @@ class NaradaBridge:
 
         if self._event_bus_ref is None:
             try:
-                from vibe_core.mahamantra.substrate.event_bus import get_event_bus
+                from vibe_core.mahamantra import get_event_bus
+
                 self._event_bus_ref = get_event_bus()
             except Exception as exc:
                 self._event_bus_failed = True

--- a/vibe_core/services/nrisimha.py
+++ b/vibe_core/services/nrisimha.py
@@ -16,7 +16,8 @@ from datetime import datetime
 from typing import Optional
 
 # LIVING SOURCE - Nrisimha springt aus der Säule
-from vibe_core.mahamantra.substrate.opcode import MAHAMANTRA_SEQUENCE, MantraOpCode
+from vibe_core.mahamantra import MAHAMANTRA_SEQUENCE, MantraOpCode
+from vibe_core.mahamantra.protocols._pancha import PanchaTattvaProtocol, TattvaDict
 from vibe_core.protocols.universal import (
     AlignmentScore,
     DriftContext,
@@ -24,7 +25,6 @@ from vibe_core.protocols.universal import (
     Resonance,
     SovereignContext,
 )
-from vibe_core.mahamantra.protocols._pancha import PanchaTattvaProtocol, TattvaDict
 
 logger = logging.getLogger("NRISIMHA_WATCHDOG")
 

--- a/vibe_core/services/udana_router.py
+++ b/vibe_core/services/udana_router.py
@@ -39,24 +39,19 @@ from datetime import datetime
 from typing import Any, Callable, Dict, Final, List, Optional
 from uuid import uuid4
 
+# Import Nadi infrastructure
+from vibe_core.mahamantra import LocalNadi, MantraOpCode, NadiProtocol, NadiType
+
 # GAD compliance
 from vibe_core.mahamantra.protocols._gad import GADBase
-
-# Import Nadi infrastructure
 from vibe_core.mahamantra.substrate.nadi import (
     NADI_CAPACITY,
     NADI_TIMEOUT_MS,
-    LocalNadi,
     NadiConnection,
     NadiMessage,
     NadiOp,
     NadiPriority,
-    NadiProtocol,
-    NadiType,
 )
-
-# Import OpCodes for routing
-from vibe_core.mahamantra.substrate.opcode import MantraOpCode
 
 # Import seed constants
 from vibe_core.mahamantra.substrate.seed import (

--- a/vibe_core/shuddhi/tests/test_remedy_loader.py
+++ b/vibe_core/shuddhi/tests/test_remedy_loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from vibe_core.mahamantra.substrate.shuddhi import RemedyProtocol
+from vibe_core.mahamantra import ShuddhiProtocol as RemedyProtocol
 from vibe_core.mahamantra.dharma.kapila.remedies.base import CSTRemedy
 from vibe_core.mahamantra.dharma.kapila.remedy_loader import (
     RemedyLoader,
@@ -162,6 +162,7 @@ class TestExpectedRemedies:
         """ShuddhiEngine should not have hardcoded remedy imports."""
         # Canonical engine location (post-Samskara migration)
         from vibe_core.mahamantra.dharma.kumaras import engine as engine_mod
+
         engine_path = Path(engine_mod.__file__)
         content = engine_path.read_text()
 


### PR DESCRIPTION
Expand CORE_MODULES in mahamantra/__init__.py to expose byte, guna, seed,
tattva, nadi, intents, io_sentinel, pancha_tattva, wiring, samskara as
public API surface. Re-route 14 production files (services, cli, boot,
gateway) from direct substrate access to `from vibe_core.mahamantra import X`.

Outer protocols/ left unchanged — circular import chain prevents routing
through mahamantra.__getattr__ (protocols/__init__.py eagerly imports
modules that re-enter mahamantra CORE_MODULES loading).

750/751 tests green (1 pre-existing API key failure).

https://claude.ai/code/session_016zAWe3tLGusdkrc7U1cHnV