### PR TITLE
Fix CLAUDE.md: 17 stale claims verified against code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # STEWARD PROTOCOL — Architecture Reference
 
-**Trust nothing written here. Verify against code. This file was last verified 2026-02-17.**
+**Trust nothing written here. Verify against code. This file was last verified 2026-02-22.**
 
 100% AI-generierte Codebase. Docstrings lügen. .md-Dateien lügen. Nur Code ist Wahrheit.
 
@@ -18,10 +18,10 @@ Every constant derives from this. If a number appears without derivation: archit
 **7 Axiome** (`protocols/seed/_axioms.py`):
 WORDS=16, TRINITY=3, HARE_COUNT=8, KRISHNA_COUNT=4, RAMA_COUNT=4, PANCHA=5, HALVES=2
 
-**Ableitungen** (`_primary.py` → `_secondary.py` → `substrate/seed.py`):
+**Ableitungen** (`_primary.py` → `_secondary.py` → `substrate/core/seed.py`):
 QUARTERS=4, KSHETRA=24, NAVA=9, SHARANAGATI=6, MAHAJANA_COUNT=12, PARAMPARA=37, GITA_CHAPTERS=18, MALA=108
 
-`seed.py` has ~20 F811 redefinitions — intentional re-derivation chains, not bugs.
+`seed.py` re-derives constants from axioms. 0 F811 violations.
 
 ---
 
@@ -29,15 +29,15 @@ QUARTERS=4, KSHETRA=24, NAVA=9, SHARANAGATI=6, MAHAJANA_COUNT=12, PARAMPARA=37, 
 
 ```
 Layer 7  CLI/User     cli/entry.py, cli/auto.py, cli/map.py
-Layer 6  Adapters     adapters/ (67 lazy-loaded classes, __getattr__ discovery)
+Layer 6  Adapters     adapters/ (52 lazy-loaded symbols + auto-discovery, __getattr__)
 Layer 5  Application  lila/, reactor/, analysis/, namarupa/, venu/
 Layer 4  Quarters     genesis/, dharma/, karma/, moksha/ (16 Mahajana folders)
 Layer 3  Governance   audit/, dharma/kapila/remedies/ (healing + compliance)
 Layer 2  Kernel       kernel/singularity.py (tick, kala, venu, routing)
                       kernel/daemon.py (heartbeat loop)
                       kernel/maha_kernel.py (Seed→Address, __call__ only)
-Layer 1  Substrate    substrate/ (53 files, 8 subdirs, LotusFinder)
-Layer 0  Protocols    protocols/ (388 importers, SSOT for types/constants)
+Layer 1  Substrate    substrate/ (106 files, 15 subdirs, LotusFinder)
+Layer 0  Protocols    protocols/ (506 import-sites across 236 files, SSOT for types/constants)
 ```
 
 **Three Core Objects (do NOT merge):**
@@ -66,7 +66,7 @@ These must NEVER use `__getattr__` routers. Pure integer dispatch only.
 
 ## 3. The VM: `__call__()` → `execute_cycle()`
 
-`__call__()` delegates to `substrate/mantra_vm.py:execute_cycle()`.
+`__call__()` delegates to `substrate/vm/mantra_vm.py:execute_cycle()`.
 12 instructions dispatched via `NavaBhaktiOp(IntEnum)` in `protocols/_navabhakti.py`.
 
 **Pure computation. No gates.** Gates fire at the boundary (`execute()`/`GovardhanGateway`).
@@ -93,7 +93,7 @@ for op in CYCLE:          # CYCLE = tuple(NavaBhaktiOp(i) for i in range(12))
 
 Each wrapper reads from `ctx` (plain dict), calls the original Lotus method, writes back to `ctx`.
 VAMSI addresses at PARAMPARA(37) stride: 37, 74, 111, ..., 444. Zero collisions with THE_FLUTE_CYCLE.
-Output: 27-key dict, key-by-key identical to the old hardcoded pipeline. 587 tests verify this.
+Output: 27-key dict, key-by-key identical to the old hardcoded pipeline. 862 tests verify this.
 
 The 9 NavaBhakti methods remain individually callable on MahamantraLotus.
 
@@ -101,7 +101,7 @@ The 9 NavaBhakti methods remain individually callable on MahamantraLotus.
 
 ## 4. DIW (Divine Instruction Word) — 19 bits
 
-`protocols/diw.py` → `substrate/venu_orchestrator.py` → `substrate/chamber.py`
+`protocols/diw.py` → `substrate/vm/venu_orchestrator.py` → `substrate/cell_system/chamber.py`
 
 ```
 Bits  0-5  (6): VENU   — Intensity (Sharanagati)
@@ -114,7 +114,7 @@ Two separate uses of VAMSI — do not confuse:
 - **mantra_vm.py**: VAMSI addresses as dispatch keys for pipeline instructions. Separate mechanism.
 
 `THE_FLUTE_CYCLE[16]` = static LUT. `VenuOrchestrator.step()` produces next DIW.
-`pack_full()` (32-bit extension) has ~0 production callers — dormant infrastructure.
+`pack_full()` (32-bit extension) has 1 production caller (`venu_orchestrator.py`).
 
 ---
 
@@ -124,14 +124,14 @@ Every phoneme = 4D address (0-48):
 COORD_ELEMENT (5), COORD_VARGA (3), COORD_SUB, COORD_HARMONIC (×SEVEN mod 49).
 49/49 bijection. 4127/4127 words unique. IS_SHRUTI = quadratic residues mod 49.
 
-`substrate/varnamala_codec.py`, `substrate/pancha_walk.py`, `adapters/synth.py`.
+`substrate/encoding/varnamala_codec.py`, `substrate/encoding/pancha_walk.py`, `adapters/synth.py`.
 `data/rama_lexicon.json`: 4127 words, 700 verses, RAMA-encoded.
 
 ---
 
 ## 6. Gate Providers (Observer Pattern)
 
-`substrate/gate_providers.py` → `wire_gate_providers()` at boot.
+`substrate/vm/gate_providers.py` → `wire_gate_providers()` at boot.
 `_fire_gate()` dispatches hooks + providers. `_GATE_DISPATCH` maps Gate→Method.
 
 | Gate | Protocol | Provider | Adapter |
@@ -165,7 +165,7 @@ No double-ticking. 17× `tick()` methods exist across the codebase — each in i
 
 ## 8. Antaranga (Inner Chamber)
 
-`substrate/antaranga.py`: 512 Slots × 32 Bytes = 16 KB `bytearray`. No Python objects. No GC.
+`substrate/cell_system/antaranga.py`: 512 Slots × 32 Bytes = 16 KB `bytearray`. No Python objects. No GC.
 
 ```
 Slot Layout (32 Bytes, Little-Endian):
@@ -186,10 +186,10 @@ Antaranga is **resonance storage**, not an instruction register file.
 
 | File | Lines | What |
 |------|-------|------|
-| `substrate/harmonics.py` | 1079 | 60+ constants, 15 importers, 12 imports. Sternkoppler. |
-| `substrate/gate_providers.py` | 919 | 5 observers, 49 imports, scattered audit trail. |
-| `substrate/resonance_ranker.py` | 836 | 7 scoring dimensions, all inline. |
-| `adapters/composition.py` | 475 | 5 scorers with lazy imports. |
+| `substrate/encoding/harmonics.py` | 1079 | 60+ constants, 15 importers, 12 imports. Sternkoppler. |
+| `substrate/vm/gate_providers.py` | 1047 | 5 observers, 49 imports, scattered audit trail. |
+| `substrate/encoding/resonance_ranker.py` | 873 | 7 scoring dimensions, all inline. |
+| `adapters/composition.py` | 361 | 5 scorers with lazy imports. |
 
 These are factual line counts. Whether they should be decomposed is a separate decision.
 
@@ -213,12 +213,12 @@ These are factual line counts. Whether they should be decomposed is a separate d
 - `guardian_router.maha_respond()` is deprecated (0 callers).
 - `chat.py` is legacy.
 - 30+ files write to disk uncontrolled. `StateService` exists, barely used.
-- Private keys in git: `data/identities/*.key`, `data/security/master.key`.
+- Private keys: No `.key` files found in repo (checked 2026-02-22). Claim was stale.
 - Tests with blocking loops hang: `test_singularity`, `test_daemon*`, `test_gad`, `test_graph`, `test_entry`.
 - **3× `get_kernel()` singletons**: `maha_kernel.py` (Seed→Address), `maha_llm_kernel.py` (LLM), `intent.py` (Intent). Different objects, same function name.
 - **`__call__()` has NO gates.** Gates fire only in `execute()`/`GovardhanGateway`. Adding gates to `__call__()` causes double-fire.
 - **Lotus ≠ Singularity.** Two objects. Facade pattern. Do not merge.
-- `mahamantra_research/` (moved from `mahamantra/research/`) is load-bearing — `_gita_lens.py`, `maha_kernel.py`, `adapters/routing.py` import from it.
+- `mahamantra_research/` (moved from `mahamantra/research/`) is load-bearing — `protocols/_gita_lens.py`, `audit/scale.py`, `audit/protocol_resurrection.py`, `audit/gaps.py`, `cli/kirtan_cli.py` import from it.
 - DIW consumers MUST use `diw.unpack()`. No manual bit-shifts.
 
 ---
@@ -229,7 +229,7 @@ These are factual line counts. Whether they should be decomposed is a separate d
 - User spricht Deutsch, delegiert.
 - Verify every claim against code. Other agents have made false claims about this codebase.
 - `python -m ruff check --select F821,F811` before every commit.
-- `python -m pytest vibe_core/mahamantra/tests/ -x -q` — 705 tests must pass.
+- `python -m pytest vibe_core/mahamantra/tests/ -x -q` — 862 tests must pass.
 - 100% AI-generated codebase — ALWAYS expect hidden problems.
 - **No blind deletion.** Check wiring before marking anything as dead.
 - **No spaghetti.** No shifting monoliths. Every change must reduce complexity, not relocate it.


### PR DESCRIPTION
- 9 substrate paths updated (files moved to vm/, encoding/, cell_system/ subdirs)
- substrate count: 53→106 files, 8→15 subdirs
- test count: 587/705→862
- monolith line counts: gate_providers 919→1047, resonance_ranker 836→873, composition 475→361
- adapter count: 67→52 lazy-loaded symbols + auto-discovery
- protocol importers: 388→506 across 236 files
- seed.py path: substrate/seed.py→substrate/core/seed.py, F811 claim removed (0 violations)
- pack_full() ~0→1 caller (Section 4 now consistent with Section 10)
- private keys claim removed (no .key files in repo)
- mahamantra_research importers corrected (was maha_kernel+routing, actually _gita_lens+audit/*+cli)

https://claude.ai/code/session_016zAWe3tLGusdkrc7U1cHnV