### PR TITLE
Add public APIs for HebbianSynaptic.restore() and CircuitBreaker.record_success/failure()

### DIFF
--- a/.vibe/state/mahamantra/maha_state.json
+++ b/.vibe/state/mahamantra/maha_state.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "timestamp": "2026-02-28T15:38:29.893220",
+  "timestamp": "2026-03-10T12:00:36.849364",
   "parampara": 37,
   "entries": {
     "balarama_test.json": {
@@ -23,25 +23,25 @@
       "key": "exists",
       "value": true,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.727617",
+      "timestamp": "2026-03-10T12:00:36.774654",
       "pierced": false,
-      "hash": "80ae69f9e893881c"
+      "hash": "f66ce1c4b35d0e00"
     },
     "a": {
       "key": "a",
       "value": 1,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.786502",
+      "timestamp": "2026-03-10T12:00:36.804733",
       "pierced": false,
-      "hash": "457f07cc61cb231e"
+      "hash": "94bd54a9eba3b648"
     },
     "b": {
       "key": "b",
       "value": 2,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.786544",
+      "timestamp": "2026-03-10T12:00:36.804773",
       "pierced": false,
-      "hash": "ed5829a46cfc5a1d"
+      "hash": "939717d87bcf3098"
     },
     "test": {
       "key": "test",
@@ -111,9 +111,9 @@
       "key": "normal",
       "value": "overridden",
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.816366",
+      "timestamp": "2026-03-10T12:00:36.818776",
       "pierced": true,
-      "hash": "3058dfd7cfb6e025"
+      "hash": "00ecbc5d9d195a51"
     },
     "pierced1": {
       "key": "pierced1",
@@ -175,28 +175,28 @@
       "key": "answer",
       "value": 42,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.697553",
+      "timestamp": "2026-03-10T12:00:36.759773",
       "pierced": false,
-      "hash": "b82c5b41bb064643"
+      "hash": "767a8478bf6630df"
     },
     "x": {
       "key": "x",
       "value": 1,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.887178",
+      "timestamp": "2026-03-10T12:00:36.848496",
       "pierced": true,
-      "hash": "c75b7b755db2bd9d"
+      "hash": "fe21546d2408e6be"
     },
     "y": {
       "key": "y",
       "value": 2,
       "source": "sovereign",
-      "timestamp": "2026-02-28T15:38:29.887227",
+      "timestamp": "2026-03-10T12:00:36.848531",
       "pierced": true,
-      "hash": "7251e1a7afb4645d"
+      "hash": "666a4d1f1647edc9"
     }
   },
-  "boot_count": 1399,
+  "boot_count": 1406,
   "thresholds": {
     "max_entries": 72,
     "kernel_reserve": 16,

--- a/.vibe/state/mahamantra/maha_state_backup/20260310_120036_maha_state.json
+++ b/.vibe/state/mahamantra/maha_state_backup/20260310_120036_maha_state.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "timestamp": "2026-02-28T14:09:26.814287",
+  "timestamp": "2026-03-10T12:00:36.834621",
   "parampara": 37,
   "entries": {
     "balarama_test.json": {
@@ -23,25 +23,25 @@
       "key": "exists",
       "value": true,
       "source": "sovereign",
-      "timestamp": "2026-02-28T14:09:26.694856",
+      "timestamp": "2026-03-10T12:00:36.774654",
       "pierced": false,
-      "hash": "d997a59e284a3236"
+      "hash": "f66ce1c4b35d0e00"
     },
     "a": {
       "key": "a",
       "value": 1,
       "source": "sovereign",
-      "timestamp": "2026-02-28T14:09:26.753352",
+      "timestamp": "2026-03-10T12:00:36.804733",
       "pierced": false,
-      "hash": "a6b03e78e9d04efb"
+      "hash": "94bd54a9eba3b648"
     },
     "b": {
       "key": "b",
       "value": 2,
       "source": "sovereign",
-      "timestamp": "2026-02-28T14:09:26.753391",
+      "timestamp": "2026-03-10T12:00:36.804773",
       "pierced": false,
-      "hash": "2010a1182cc9429d"
+      "hash": "939717d87bcf3098"
     },
     "test": {
       "key": "test",
@@ -111,9 +111,9 @@
       "key": "normal",
       "value": "overridden",
       "source": "sovereign",
-      "timestamp": "2026-02-28T14:09:26.782535",
+      "timestamp": "2026-03-10T12:00:36.818776",
       "pierced": true,
-      "hash": "9dea48449755f08c"
+      "hash": "00ecbc5d9d195a51"
     },
     "pierced1": {
       "key": "pierced1",
@@ -175,28 +175,28 @@
       "key": "answer",
       "value": 42,
       "source": "sovereign",
-      "timestamp": "2026-02-28T14:09:26.665008",
+      "timestamp": "2026-03-10T12:00:36.759773",
       "pierced": false,
-      "hash": "45f74472ba604ac6"
+      "hash": "767a8478bf6630df"
     },
     "x": {
       "key": "x",
       "value": 1,
       "source": "sovereign",
-      "timestamp": "2026-02-27T21:29:06.772888",
+      "timestamp": "2026-02-28T15:38:29.887178",
       "pierced": true,
-      "hash": "91cbb5784e38c6ec"
+      "hash": "c75b7b755db2bd9d"
     },
     "y": {
       "key": "y",
       "value": 2,
       "source": "sovereign",
-      "timestamp": "2026-02-27T21:29:06.772926",
+      "timestamp": "2026-02-28T15:38:29.887227",
       "pierced": true,
-      "hash": "8d8c9d4e1b7003fc"
+      "hash": "7251e1a7afb4645d"
     }
   },
-  "boot_count": 1377,
+  "boot_count": 1405,
   "thresholds": {
     "max_entries": 72,
     "kernel_reserve": 16,

--- a/vibe_core/mahamantra/substrate/manas/synaptic.py
+++ b/vibe_core/mahamantra/substrate/manas/synaptic.py
@@ -105,6 +105,14 @@ class HebbianSynaptic:
         """Return copy of current weights."""
         return dict(self._weights)
 
+    def restore(self, weights: Dict[str, float]) -> None:
+        """Restore weights from a dict (counterpart to snapshot()).
+
+        Replaces all current weights. Values are clamped to [0, 1].
+        """
+        self._weights = {k: max(0.0, min(1.0, float(v))) for k, v in weights.items()}
+        self._dirty = True
+
     def decay(self, factor: float = 0.01) -> int:
         """Apply temporal decay: all weights regress toward 0.5 (default).
 

--- a/vibe_core/runtime/circuit_breaker.py
+++ b/vibe_core/runtime/circuit_breaker.py
@@ -262,6 +262,18 @@ class CircuitBreaker:
 
         logger.info(f"Circuit Breaker state transition: {old_state} → {new_state.value}")
 
+    def record_success(self) -> None:
+        """Public API: record a successful request."""
+        self._record_success()
+
+    def record_failure(self, error: Exception) -> None:
+        """Public API: record a failed request.
+
+        Args:
+            error: The exception that was raised
+        """
+        self._record_failure(error)
+
     def get_status(self) -> dict[str, Any]:
         """
         Get current circuit breaker status.


### PR DESCRIPTION
- HebbianSynaptic.restore(dict): counterpart to snapshot(), allows weight restoration
  from external dict with clamping to [0, 1]
- CircuitBreaker.record_success() / record_failure(): public wrappers around private
  methods, enabling steward-protocol to record outcomes without accessing internals

https://claude.ai/code/session_012vggSnVKWid18EWTCM3nMw