### PR TITLE
fix(ci): install [crypto] extra in Holon Factory

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e ".[crypto]"
 
     - name: Build ALL Plugin Containers
       run: |


### PR DESCRIPTION
Holon Factory (`factory.yml`) runs `pip install -e .` without extras, then signs holons with ECDSA in the build step — but `ecdsa` lives in the `crypto` optional-dependency group (intentional, since the 31→2 core-deps split for PyPI). Result: `ecdsa not installed`, build fails (run 28533446599).

Fix: pull the `crypto` extra in the install step, matching the pattern `steward-ci.yml` already uses (`.[city,dev]`). No version bump, no pyproject change, no runtime deps added to the published package — crypto is only pulled in CI.