### PR TITLE
fix: restore phonetic locality channel

### DIFF
--- a/vibe_core/mahamantra/adapters/compression.py
+++ b/vibe_core/mahamantra/adapters/compression.py
@@ -140,14 +140,15 @@ def _compute_seed_cached(text: str) -> int:
     vibrations = text_to_vibration(text)
     vibration_sum = sum(sig.signature_id for sig in vibrations) if vibrations else 0
 
-    # MERGE: XOR hash with vibration_sum — phonetics modulate the hash
-    # This is NOT symmetric destruction (like seed^seed=0) because
-    # text_hash and vibration_sum are structurally different values.
-    merged = text_hash ^ (vibration_sum & 0xFFFFFFFF)
+    # Channel 1 — locality: classification follows phonetics.
+    # Keep the phonetic signal out of the identity bits so a uniformly
+    # distributed hash cannot erase its locality through XOR.
+    category = vibration_sum % WORDS  # 0-15, phonetically stable
 
-    category = merged % WORDS  # 0-15, phonetically influenced
+    # Channel 2 — identity: uniqueness remains with the structural hash.
+    identity = text_hash % MAHA_QUANTUM
 
-    base_seed = (category * MAHA_QUANTUM) + (merged % MAHA_QUANTUM)
+    base_seed = (category * MAHA_QUANTUM) + identity
 
     synth = MahaModularSynth(default_preset="quantum")
     transformed = synth.transform(base_seed)

--- a/vibe_core/mahamantra/adapters/compression.py
+++ b/vibe_core/mahamantra/adapters/compression.py
@@ -229,7 +229,7 @@ class MahaCompression(MahaCompressionProtocol):
         seed = self._compute_seed(text)
 
         # Position in 16-word grid
-        position = seed % WORDS
+        position = (seed >> 24) % WORDS
 
         # Generate summary if requested
         summary = None
@@ -337,7 +337,7 @@ class MahaCompression(MahaCompressionProtocol):
         """
         # Use seed properties to infer intent
         # This is deterministic but approximate
-        position = seed % WORDS
+        position = (seed >> 24) % WORDS
 
         # Map positions to gunas (simplified)
         # 0-3 = TAMAS, 4-7 = RAJAS, 8-11 = SATTVA, 12-15 = SUDDHA

--- a/vibe_core/mahamantra/substrate/lotus_core.py
+++ b/vibe_core/mahamantra/substrate/lotus_core.py
@@ -793,11 +793,15 @@ class MahamantraLotus(LotusNode, GADBase, GADProtocol):
         }
 
     @staticmethod
-    def dasyam(attractor: int, opcode: Optional[int] = None) -> dict:
+    def dasyam(
+        attractor: int,
+        opcode: Optional[int] = None,
+        category: Optional[int] = None,
+    ) -> dict:
         """7. DASYAM + SHABDA — Position/Quarter/Role + RAMA Grid phoneme signature."""
         P = _get_pipeline()
         WORDS = P.WORDS
-        position = attractor % WORDS
+        position = (category % WORDS) if category is not None else (attractor % WORDS)
 
         diw = P.THE_FLUTE_CYCLE[position]
         diw_comp = P.diw_components[position]

--- a/vibe_core/mahamantra/substrate/vm/mantra_vm.py
+++ b/vibe_core/mahamantra/substrate/vm/mantra_vm.py
@@ -80,7 +80,7 @@ def _w_vandanam(lotus: "MahamantraLotus", ctx: dict) -> None:
 
 
 def _w_dasyam(lotus: "MahamantraLotus", ctx: dict) -> None:
-    d = lotus.dasyam(ctx["attractor"], ctx.get("opcode"))
+    d = lotus.dasyam(ctx["attractor"], ctx.get("opcode"), category=ctx["seed"] >> 24)
     ctx["position"] = d["position"]
     ctx["diw"] = d["diw"]
     ctx["diw_comp"] = d["diw_comp"]

--- a/vibe_core/mahamantra/tests/test_language_engine.py
+++ b/vibe_core/mahamantra/tests/test_language_engine.py
@@ -4,6 +4,8 @@ Tests for substrate/language/engine.py — MahaLanguageEngine orchestrator.
 Tests the full pipeline end-to-end. Determinism is the core invariant.
 """
 
+import re
+
 import pytest
 
 from vibe_core.mahamantra.protocols._seed import PARAMPARA
@@ -76,7 +78,7 @@ class TestGenerate:
 
     def test_verse_ref_format(self, engine):
         result = engine.generate("the meaning of sacrifice")
-        assert result.verse_ref.startswith("BG.18.")
+        assert re.match(r"^BG\.\d{1,2}\.\d{1,2}$", result.verse_ref)
 
     def test_output_nonempty(self, engine):
         result = engine.generate("who am I?")


### PR DESCRIPTION
## Was

Kanaltrennung in `_compute_seed_cached()` + Konsumenten auf das Kategoriefeld.

Der phonetische Kanal (`vibration_sum`) wurde per XOR mit SHA256 zusammengeführt
und dadurch ausgelöscht — XOR mit einem gleichverteilten Wert ergibt einen
gleichverteilten Wert. Die Klassifikation lief auf Avalanche-Rauschen: dieselbe
Eingabe mit abweichender Interpunktion erhielt eine andere Kategorie.

Der Docstring von `_compute_seed_cached()` beschreibt bereits das beabsichtigte
Verhalten. Dieser PR stellt es her.

Fundstellen:
- `compression.py` `_compute_seed_cached()` — Kanaltrennung
- `compression.py` Zeilen 231, 339 — Konsumenten lesen (`seed >> 24`)
- `lotus_core.py` `dasyam()` — `category`-Parameter, rückwärtskompatibel
- `vm/mantra_vm.py` `_w_dasyam()` — Durchreichung aus `ctx["seed"]`

## Verhaltensnachweis

Vier Varianten derselben Eingabe (Punkt, Großschreibung, Leerzeichen):

  vorher: 4 verschiedene Klassifikationen
  nachher: stabil `position=10`, `guna=sattva`, `action=debug`

## Testlage — Delta gegen Baseline

`vibe_core/mahamantra/`: 4 rot vorher → 4 rot nachher (Delta 0)
`steward/tests/`: grün → grün (Delta 0)

Die vier Protocol-Failures sind vorbestehende `shabda_aligner`-Tests und nicht
Gegenstand dieses PR. Die Steward-Suite endet mit `2463 passed, 4 skipped`.

Eine bestehende Teständerung: `test_verse_ref_format` prüfte einen
seed-abgeleiteten Kapitelwert unter einem Format-Namen. Auf Formatprüfung
umgestellt — das Kapitel ist kein stabiler Vertrag. Begründung steht im Commit.

## Blast Radius

Prozessintern. Nicht berührt: Identität (`STEWARD_IDENTITY_SEED`),
Föderations-Fingerprints, Wire-Protokoll, Peer-IDs, persistente Zustandsdateien.
Keine Datenmigration. Rollback = Reversion.

Nebenwirkung: Hebbian-Store-Schlüssel (`seed:{n}`) verwaisen. Konfidenzen
starten bei 0, Antwort-Cache und Tier-Eskalation zunächst inaktiv.
Erwartet — siehe Aufgabe 6.

## Nicht Gegenstand dieses PR

- `BuddhiDirective.tool_names` bleibt unverbunden (`buddhi.py:431`). Bekannt,
  gewollt. Anbinden vor einer Entscheidung über beratend/sperrend erzeugt einen
  Defekt, statt einen zu beheben.
- North-Star-Alignment bleibt abgeklemmt (`engine.py:267`). Die Metrik ist
  derzeit gegenläufig zur Bedeutung und wird separat repariert.
