### PR TITLE
ci: pin Ruff to 0.15.21

### DIFF
--- a/.github/workflows/steward-ci.yml
+++ b/.github/workflows/steward-ci.yml
@@ -123,7 +123,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.15.21
 
       - name: Ruff check (critical)
         run: ruff check vibe_core scripts --select=E9,F63,F7,F82 --output-format=github


### PR DESCRIPTION
## Was

Ruff in der CI auf 0.15.21 gebunden.

## Warum

`pip install ruff` zieht die jeweils neueste Version. Zwischen dem letzten
grünen main-Lauf (0.15.21) und PR #2047 erschien 0.16.1, deren
Formatierungsregeln 42 unveränderte Bestandsdateien beanstanden. Damit werden
PRs durch Ereignisse rot, die nichts mit ihrem Inhalt zu tun haben.

0.15.21 ist die Version, mit der main zuletzt grün lief.

## Nicht Gegenstand

Die 42 Dateien werden nicht formatiert. Ein Wechsel auf 0.16.x erfordert
einen eigenen Formatierungslauf und wird gesondert entschieden.
