### PR TITLE
release: steward-protocol 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "steward-protocol"
-version = "0.3.2"
+version = "0.3.3"
 description = "Cryptographic Identity + Governance for AI Agents. A.G.I. Infrastructure."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Was

Versionsprung von `steward-protocol` auf `0.3.3`.

## Warum

Release der gemergten Kanaltrennung und der korrigierten Seed-Konsumenten aus
PR #2047.

## Änderung

Nur `pyproject.toml` wurde aktualisiert. Keine weiteren Dateien geändert.
